### PR TITLE
WIP: Render glyphs using canvas

### DIFF
--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -16,6 +16,10 @@ pub struct AppRunner {
     last_save_time: f64,
     pub(crate) text_agent: TextAgent,
 
+    // MEMBRANE: support native dragging.
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) native_drag_payload: Option<String>,
+
     // Output for the last run:
     textures_delta: TexturesDelta,
     clipped_primitives: Option<Vec<egui::ClippedPrimitive>>,
@@ -120,6 +124,9 @@ impl AppRunner {
             needs_repaint,
             last_save_time: now_sec(),
             text_agent,
+            // MEMBRANE: support native dragging.
+            #[cfg(target_arch = "wasm32")]
+            native_drag_payload: None,
             textures_delta: Default::default(),
             clipped_primitives: None,
         };
@@ -275,6 +282,8 @@ impl AppRunner {
             copied_text,
             events: _,                    // already handled
             mutable_text_under_cursor: _, // TODO(#4569): https://github.com/emilk/egui/issues/4569
+            #[cfg(target_arch = "wasm32")]
+            native_drag_payload,
             ime,
             #[cfg(feature = "accesskit")]
                 accesskit_update: _, // not currently implemented
@@ -292,6 +301,13 @@ impl AppRunner {
 
         #[cfg(not(web_sys_unstable_apis))]
         let _ = copied_text;
+
+        // MEMBRANE: support native dragging. It's possible that the egui drag starts before the native dragstart event
+        // is fired by the DOM element, so we keep the payload here.
+        #[cfg(target_arch = "wasm32")]
+        if native_drag_payload.is_some() {
+            self.native_drag_payload = native_drag_payload;
+        }
 
         if self.has_focus() {
             // The eframe app has focus.

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -784,7 +784,80 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
         }
     })?;
 
+    // MEMBRANE: Support dragging things natively outside of the canvas.
+    runner_ref.add_event_listener(target, "dragstart", |event: web_sys::DragEvent, runner| {
+        if let Some(data_transfer) = event.data_transfer() {
+            runner.input.raw.native_drag_starting = true;
+
+            let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
+            runner.input.raw.events.push(egui::Event::PointerMoved(pos));
+
+            // Run the logic synchronously to allow the app to set the DragAndDrop payload.
+            runner.logic();
+
+            runner.input.raw.native_drag_starting = false;
+
+            if let Some(data) = runner.native_drag_payload.take() {
+                if let Err(err) = set_transfer_text(data.as_str(), data_transfer) {
+                    log::error!("Failed to set transfer text: {:?}", err);
+                }
+            } else {
+                // Don't let the browser drag the entire canvas
+                event.stop_propagation();
+                event.prevent_default();
+            }
+            runner.needs_repaint.repaint_asap();
+        }
+    })?;
+
+    // MEMBRANE: Support dragging things natively outside of the canvas.
+    runner_ref.add_event_listener(target, "dragend", |event: web_sys::DragEvent, runner| {
+        runner.input.raw.hovered_items.clear();
+        if let Some(button) = button_from_mouse_event(&event) {
+            // Send this event because pointerup is not fired when dragging
+            let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
+            let modifiers = runner.input.raw.modifiers;
+            let events = &mut runner.input.raw.events;
+            events.push(egui::Event::PointerButton {
+                pos,
+                button,
+                pressed: false,
+                modifiers,
+            });
+            runner.needs_repaint.repaint_asap();
+            clean_up_transfer_text();
+        }
+    })?;
+
     Ok(())
+}
+
+fn set_transfer_text(data: &str, data_transfer: web_sys::DataTransfer) -> Result<(), &'static str> {
+    let window = web_sys::window().ok_or("Failed to get window")?;
+    let document = window.document().ok_or("Failed to get document")?;
+    let element = document
+        .create_element("div")
+        .map_err(|_| "Failed to create element")?;
+    element.set_id("eframe-dragged-element");
+    document
+        .body()
+        .ok_or("Failed to get document body")?
+        .append_child(&element)
+        .map_err(|_| "Failed to append child element")?;
+    element.set_text_content(Some(data));
+    data_transfer
+        .set_data("text/plain", &data)
+        .map_err(|_| "Failed to set data transfer")?;
+    data_transfer.set_drag_image(&element, 0, 0);
+    Ok(())
+}
+
+fn clean_up_transfer_text() {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    if let Some(element) = document.get_element_by_id("eframe-dragged-element") {
+        element.remove();
+    }
 }
 
 /// Install a `ResizeObserver` to observe changes to the size of the canvas.

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -56,7 +56,8 @@ pub(crate) fn install_event_handlers(runner_ref: &WebRunner) -> Result<(), JsVal
     let document = window.document().unwrap();
     let canvas = runner_ref.try_lock().unwrap().canvas().clone();
 
-    install_blur_focus(runner_ref, &canvas)?;
+    // MEMBRANE: for some reason canvas doesn't get these events in the vscode iframe so use window instead.
+    install_blur_focus(runner_ref, &window)?;
 
     prevent_default_and_stop_propagation(
         runner_ref,

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -634,28 +634,51 @@ fn install_wheel(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsV
 fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsValue> {
     runner_ref.add_event_listener(target, "dragover", |event: web_sys::DragEvent, runner| {
         if let Some(data_transfer) = event.data_transfer() {
-            runner.input.raw.hovered_files.clear();
-
-            // NOTE: data_transfer.files() is always empty in dragover
+            runner.input.raw.hovered_items.clear();
 
             let items = data_transfer.items();
             for i in 0..items.length() {
                 if let Some(item) = items.get(i) {
-                    runner.input.raw.hovered_files.push(egui::HoveredFile {
-                        mime: item.type_(),
-                        ..Default::default()
-                    });
+                    match item.kind().as_str() {
+                        "file" => {
+                            let Ok(Some(file)) = item.get_as_file() else {
+                                continue;
+                            };
+                            runner.input.raw.hovered_items.push(egui::HoveredItem::File(
+                                egui::HoveredFile {
+                                    mime: file.type_(),
+                                    ..Default::default()
+                                },
+                            ));
+                        }
+                        "string" => {
+                            runner
+                                .input
+                                .raw
+                                .hovered_items
+                                .push(egui::HoveredItem::String(egui::HoveredString {
+                                    mime: item.type_(),
+                                }));
+                        }
+                        _ => {
+                            log::warn!("Unsupported item kind: {:?}", item.kind());
+                        }
+                    }
                 }
             }
 
-            if runner.input.raw.hovered_files.is_empty() {
+            if runner.input.raw.hovered_items.is_empty() {
                 // Fallback: just preview anything. Needed on Desktop Safari.
                 runner
                     .input
                     .raw
-                    .hovered_files
-                    .push(egui::HoveredFile::default());
+                    .hovered_items
+                    .push(egui::HoveredItem::File(egui::HoveredFile::default()));
             }
+
+            // When dragging over, mousemove is not fired.
+            let pos = pos_from_mouse_event(runner.canvas(), &event, runner.egui_ctx());
+            runner.input.raw.events.push(egui::Event::PointerMoved(pos));
 
             runner.needs_repaint.repaint_asap();
             event.stop_propagation();
@@ -664,7 +687,7 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
     })?;
 
     runner_ref.add_event_listener(target, "dragleave", |event: web_sys::DragEvent, runner| {
-        runner.input.raw.hovered_files.clear();
+        runner.input.raw.hovered_items.clear();
         runner.needs_repaint.repaint_asap();
         event.stop_propagation();
         event.prevent_default();
@@ -676,47 +699,82 @@ fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result
         move |event: web_sys::DragEvent, runner| {
             if let Some(data_transfer) = event.data_transfer() {
                 // TODO(https://github.com/emilk/egui/issues/3702): support dropping folders
-                runner.input.raw.hovered_files.clear();
+                runner.input.raw.hovered_items.clear();
                 runner.needs_repaint.repaint_asap();
 
-                if let Some(files) = data_transfer.files() {
-                    for i in 0..files.length() {
-                        if let Some(file) = files.get(i) {
-                            let name = file.name();
-                            let mime = file.type_();
-                            let last_modified = std::time::UNIX_EPOCH
-                                + std::time::Duration::from_millis(file.last_modified() as u64);
+                let items = data_transfer.items();
+                for i in 0..items.length() {
+                    if let Some(item) = items.get(i) {
+                        match item.kind().as_str() {
+                            "file" => {
+                                let Ok(Some(file)) = item.get_as_file() else {
+                                    continue;
+                                };
+                                let name = file.name();
+                                let mime = file.type_();
+                                let last_modified = std::time::UNIX_EPOCH
+                                    + std::time::Duration::from_millis(file.last_modified() as u64);
 
-                            log::debug!("Loading {:?} ({} bytes)…", name, file.size());
+                                log::debug!("Loading {:?} ({} bytes)…", name, file.size());
 
-                            let future = wasm_bindgen_futures::JsFuture::from(file.array_buffer());
+                                let future =
+                                    wasm_bindgen_futures::JsFuture::from(file.array_buffer());
 
-                            let runner_ref = runner_ref.clone();
-                            let future = async move {
-                                match future.await {
-                                    Ok(array_buffer) => {
-                                        let bytes = js_sys::Uint8Array::new(&array_buffer).to_vec();
-                                        log::debug!("Loaded {:?} ({} bytes).", name, bytes.len());
-
-                                        if let Some(mut runner_lock) = runner_ref.try_lock() {
-                                            runner_lock.input.raw.dropped_files.push(
-                                                egui::DroppedFile {
-                                                    name,
-                                                    mime,
-                                                    last_modified: Some(last_modified),
-                                                    bytes: Some(bytes.into()),
-                                                    ..Default::default()
-                                                },
+                                let runner_ref = runner_ref.clone();
+                                let future = async move {
+                                    match future.await {
+                                        Ok(array_buffer) => {
+                                            let bytes =
+                                                js_sys::Uint8Array::new(&array_buffer).to_vec();
+                                            log::debug!(
+                                                "Loaded {:?} ({} bytes).",
+                                                name,
+                                                bytes.len()
                                             );
-                                            runner_lock.needs_repaint.repaint_asap();
+
+                                            if let Some(mut runner_lock) = runner_ref.try_lock() {
+                                                runner_lock.input.raw.dropped_items.push(
+                                                    egui::DroppedItem::File(egui::DroppedFile {
+                                                        name,
+                                                        mime,
+                                                        last_modified: Some(last_modified),
+                                                        bytes: Some(bytes.into()),
+                                                        ..Default::default()
+                                                    }),
+                                                );
+                                                runner_lock.needs_repaint.repaint_asap();
+                                            }
+                                        }
+                                        Err(err) => {
+                                            log::error!("Failed to read file: {:?}", err);
                                         }
                                     }
-                                    Err(err) => {
-                                        log::error!("Failed to read file: {:?}", err);
+                                };
+                                wasm_bindgen_futures::spawn_local(future);
+                            }
+                            "string" => {
+                                let runner_ref = runner_ref.clone();
+                                let mime = item.type_();
+                                let closure = Closure::once(move |contents: String| {
+                                    if let Some(mut runner_lock) = runner_ref.try_lock() {
+                                        runner_lock.input.raw.dropped_items.push(
+                                            egui::DroppedItem::String(egui::DroppedString {
+                                                contents,
+                                                mime,
+                                            }),
+                                        );
+                                        runner_lock.needs_repaint.repaint_asap();
                                     }
+                                });
+                                if let Err(err) = item
+                                    .get_as_string(Some(closure.into_js_value().unchecked_ref()))
+                                {
+                                    log::error!("Failed to read dropped string: {:?}", err);
                                 }
-                            };
-                            wasm_bindgen_futures::spawn_local(future);
+                            }
+                            _ => {
+                                log::warn!("Unsupported item kind: {:?}", item.kind());
+                            }
                         }
                     }
                 }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -109,6 +109,19 @@ fn install_blur_focus(runner_ref: &WebRunner, target: &EventTarget) -> Result<()
             if event_name == "blur" {
                 // This might be a good time to save the state
                 runner.save();
+
+                // MEMBRANE: Some keyboard shortcuts steal away the focus from egui which means we won't get keyup
+                // events for those shortcut keys.
+                let keys_down = runner.egui_ctx().input(|i| i.keys_down.clone());
+                for key in keys_down {
+                    runner.input.raw.events.push(egui::Event::Key {
+                        key,
+                        physical_key: None,
+                        pressed: false,
+                        repeat: false,
+                        modifiers: egui::Modifiers::NONE,
+                    });
+                }
             }
         };
 
@@ -190,7 +203,8 @@ pub(crate) fn on_keydown(event: web_sys::KeyboardEvent, runner: &mut AppRunner) 
         }
 
         // Assume egui uses all key events, and don't let them propagate to parent elements.
-        event.stop_propagation();
+        // MEMBRANE: Stopping propagation here prevents vscode from handling key events while gaze is focused.
+        // event.stop_propagation();
     }
 }
 
@@ -274,7 +288,8 @@ pub(crate) fn on_keyup(event: web_sys::KeyboardEvent, runner: &mut AppRunner) {
     let has_focus = runner.input.raw.focused;
     if has_focus {
         // Assume egui uses all key events, and don't let them propagate to parent elements.
-        event.stop_propagation();
+        // MEMBRANE: Stopping propagation here prevents vscode from handling key events while gaze is focused.
+        // event.stop_propagation();
     }
 }
 

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -31,6 +31,7 @@ impl TextAgent {
         style.set_property("position", "absolute")?;
         style.set_property("top", "0")?;
         style.set_property("left", "0")?;
+        style.set_property("pointer-events", "none")?;
         document.body().unwrap().append_child(&input)?;
 
         // attach event listeners

--- a/crates/egui-winit/src/lib.rs
+++ b/crates/egui-winit/src/lib.rs
@@ -406,7 +406,7 @@ impl State {
                 }
             }
             WindowEvent::HoveredFile(path) => {
-                self.egui_input.hovered_files.push(egui::HoveredFile {
+                self.egui_input.hovered_items.push(egui::HoveredFile {
                     path: Some(path.clone()),
                     ..Default::default()
                 });
@@ -416,15 +416,15 @@ impl State {
                 }
             }
             WindowEvent::HoveredFileCancelled => {
-                self.egui_input.hovered_files.clear();
+                self.egui_input.hovered_items.clear();
                 EventResponse {
                     repaint: true,
                     consumed: false,
                 }
             }
             WindowEvent::DroppedFile(path) => {
-                self.egui_input.hovered_files.clear();
-                self.egui_input.dropped_files.push(egui::DroppedFile {
+                self.egui_input.hovered_items.clear();
+                self.egui_input.dropped_items.push(egui::DroppedFile {
                     path: Some(path.clone()),
                     ..Default::default()
                 });

--- a/crates/egui/src/containers/panel.rs
+++ b/crates/egui/src/containers/panel.rs
@@ -342,7 +342,7 @@ impl SidePanel {
             // In the meantime: nudge the line so its inside the panel, so it won't be covered by neighboring panel
             // (hence the shrink).
             let resize_x = side.opposite().side_x(rect.shrink(1.0));
-            let resize_x = ui.painter().round_to_pixel(resize_x);
+            let resize_x = ui.painter().round_to_pixel_center(resize_x);
             ui.painter().vline(resize_x, panel_rect.y_range(), stroke);
         }
 
@@ -831,7 +831,7 @@ impl TopBottomPanel {
             // In the meantime: nudge the line so its inside the panel, so it won't be covered by neighboring panel
             // (hence the shrink).
             let resize_y = side.opposite().side_y(rect.shrink(1.0));
-            let resize_y = ui.painter().round_to_pixel(resize_y);
+            let resize_y = ui.painter().round_to_pixel_center(resize_y);
             ui.painter().hline(panel_rect.x_range(), resize_y, stroke);
         }
 

--- a/crates/egui/src/containers/popup.rs
+++ b/crates/egui/src/containers/popup.rs
@@ -204,7 +204,11 @@ fn show_tooltip_at_dyn<'c, R>(
             // will stick around when you try to click them.
             ui.style_mut().interaction.selectable_labels = false;
 
-            Frame::popup(&ctx.style()).show_dyn(ui, add_contents).inner
+            // MEMBRANE: Menu margins don't really work well for tooltips.
+            Frame::popup(&ctx.style())
+                .inner_margin(Margin::symmetric(8.0, 4.0))
+                .show_dyn(ui, add_contents)
+                .inner
         });
 
     state.tooltip_count += 1;

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -43,6 +43,8 @@ pub struct Resize {
 
     with_stroke: bool,
     drag_corner: Align2,
+
+    snap_to_size: Option<(Vec2, Vec2)>,
 }
 
 impl Default for Resize {
@@ -56,6 +58,7 @@ impl Default for Resize {
             default_size: vec2(320.0, 128.0), // TODO(emilk): preferred size of [`Resize`] area.
             with_stroke: true,
             drag_corner: Align2::RIGHT_BOTTOM,
+            snap_to_size: None,
         }
     }
 }
@@ -193,6 +196,12 @@ impl Resize {
         self
     }
 
+    #[inline]
+    pub fn snap_to_size(mut self, snap: Vec2, snap_offset: Vec2) -> Self {
+        self.snap_to_size = Some((snap, snap_offset));
+        self
+    }
+
     /// MEMBRANE: Sets the size of the [`Resize`] area from its id.
     pub fn request_size(ctx: &Context, id: Id, size: Vec2) {
         if let Some(mut state) = State::load(ctx, id) {
@@ -277,6 +286,12 @@ impl Resize {
 
         if let Some(user_requested_rect) = user_requested_rect {
             state.desired_size = user_requested_rect.size();
+
+            // MEMBRANE: Snap to dashboard grid
+            if let Some((snap, snap_offset)) = self.snap_to_size {
+                state.desired_size =
+                    ((state.desired_size) / snap).round() * snap - snap_offset * 2.0;
+            }
         } else {
             // We are not being actively resized, so auto-expand to include size of last frame.
             // This prevents auto-shrinking if the contents contain width-filling widgets (separators etc)

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -192,6 +192,14 @@ impl Resize {
         self.with_stroke = with_stroke;
         self
     }
+
+    /// MEMBRANE: Sets the size of the [`Resize`] area from its id.
+    pub fn request_size(ctx: &Context, id: Id, size: Vec2) {
+        if let Some(mut state) = State::load(ctx, id) {
+            state.requested_size = Some(size);
+            state.store(ctx, id);
+        }
+    }
 }
 
 struct Prepared {

--- a/crates/egui/src/containers/resize.rs
+++ b/crates/egui/src/containers/resize.rs
@@ -18,11 +18,11 @@ pub(crate) struct State {
 
 impl State {
     pub fn load(ctx: &Context, id: Id) -> Option<Self> {
-        ctx.data_mut(|d| d.get_persisted(id))
+        ctx.data_mut(|d| d.get_temp(id))
     }
 
     pub fn store(self, ctx: &Context, id: Id) {
-        ctx.data_mut(|d| d.insert_persisted(id, self));
+        ctx.data_mut(|d| d.insert_temp(id, self));
     }
 }
 
@@ -42,6 +42,7 @@ pub struct Resize {
     default_size: Vec2,
 
     with_stroke: bool,
+    drag_corner: Align2,
 }
 
 impl Default for Resize {
@@ -54,6 +55,7 @@ impl Default for Resize {
             max_size: Vec2::splat(f32::INFINITY),
             default_size: vec2(320.0, 128.0), // TODO(emilk): preferred size of [`Resize`] area.
             with_stroke: true,
+            drag_corner: Align2::RIGHT_BOTTOM,
         }
     }
 }
@@ -132,6 +134,11 @@ impl Resize {
         self
     }
 
+    pub fn drag_corner(mut self, corner: Align2) -> Self {
+        self.drag_corner = corner;
+        self
+    }
+
     /// Won't expand to larger than this
     #[inline]
     pub fn max_width(mut self, max_width: f32) -> Self {
@@ -196,7 +203,7 @@ struct Prepared {
 
 impl Resize {
     fn begin(&mut self, ui: &mut Ui) -> Prepared {
-        let position = ui.available_rect_before_wrap().min;
+        let left_top = ui.available_rect_before_wrap().min;
         let id = self.id.unwrap_or_else(|| {
             let id_source = self.id_source.unwrap_or_else(|| Id::new("resize"));
             ui.make_persistent_id(id_source)
@@ -225,7 +232,12 @@ impl Resize {
             .at_least(self.min_size)
             .at_most(self.max_size);
 
-        let mut user_requested_size = state.requested_size.take();
+        let rect = Rect::from_min_size(left_top, state.desired_size);
+
+        let mut user_requested_rect = state
+            .requested_size
+            .take()
+            .map(|size| Rect::from_min_size(left_top, size));
 
         let corner_id = self.resizable.any().then(|| id.with("__resize_corner"));
 
@@ -233,14 +245,30 @@ impl Resize {
             if let Some(corner_response) = ui.ctx().read_response(corner_id) {
                 if let Some(pointer_pos) = corner_response.interact_pointer_pos() {
                     // Respond to the interaction early to avoid frame delay.
-                    user_requested_size =
-                        Some(pointer_pos - position + 0.5 * corner_response.rect.size());
+                    // user_requested_size =
+                    //     Some(pointer_pos - position + 0.5 * corner_response.rect.size());
+                    let corner_size = Vec2::splat(ui.visuals().resize_corner_size);
+                    let corner_pos = match self.drag_corner {
+                        Align2::LEFT_TOP => pointer_pos - corner_size * 0.5,
+                        Align2::LEFT_BOTTOM => {
+                            pointer_pos + vec2(-corner_size.x, corner_size.y) * 0.5
+                        }
+                        Align2::RIGHT_TOP => {
+                            pointer_pos + vec2(corner_size.x, -corner_size.y) * 0.5
+                        }
+                        Align2::RIGHT_BOTTOM => pointer_pos + corner_size * 0.5,
+                        _ => panic!("Invalid corner alignment"),
+                    };
+
+                    let mut requested_rect = rect;
+                    requested_rect.set_corner(corner_pos, self.drag_corner);
+                    user_requested_rect = Some(requested_rect);
                 }
             }
         }
 
-        if let Some(user_requested_size) = user_requested_size {
-            state.desired_size = user_requested_size;
+        if let Some(user_requested_rect) = user_requested_rect {
+            state.desired_size = user_requested_rect.size();
         } else {
             // We are not being actively resized, so auto-expand to include size of last frame.
             // This prevents auto-shrinking if the contents contain width-filling widgets (separators etc)
@@ -255,7 +283,13 @@ impl Resize {
 
         // ------------------------------
 
-        let inner_rect = Rect::from_min_size(position, state.desired_size);
+        let inner_rect = if let Some(mut user_requested_rect) = user_requested_rect {
+            user_requested_rect
+                .set_size_with_anchor(state.desired_size, self.drag_corner.opposite());
+            user_requested_rect
+        } else {
+            Rect::from_min_size(left_top, state.desired_size)
+        };
 
         let mut content_clip_rect = inner_rect.expand(ui.visuals().clip_rect_margin);
 
@@ -325,12 +359,26 @@ impl Resize {
 
         let corner_response = if let Some(corner_id) = corner_id {
             // We do the corner interaction last to place it on top of the content:
+            let rect = Rect::from_min_size(content_ui.min_rect().left_top(), state.desired_size);
             let corner_size = Vec2::splat(ui.visuals().resize_corner_size);
-            let corner_rect = Rect::from_min_size(
-                content_ui.min_rect().left_top() + size - corner_size,
-                corner_size,
-            );
+            // let corner_rect = Rect::from_min_size(
+            //     content_ui.min_rect().left_top() + size - corner_size,
+            //     corner_size,
+            // );
+
+            let corner_rect = self.drag_corner.align_size_within_rect(corner_size, rect);
             Some(ui.interact(corner_rect, corner_id, Sense::drag()))
+
+            // let corner_response = ui.ctx().interact(
+            //     ui.clip_rect(),
+            //     ui.spacing().item_spacing,
+            //     ui.layer_id(),
+            //     // LayerId::new(Order::Foreground, ui.id()),
+            //     id,
+            //     corner_rect,
+            //     Sense::drag(),
+            //     ui.is_enabled(),
+            // );
         } else {
             None
         };
@@ -348,10 +396,15 @@ impl Resize {
         }
 
         if let Some(corner_response) = corner_response {
-            paint_resize_corner(ui, &corner_response);
+            paint_resize_corner(ui, &corner_response, self.drag_corner);
 
             if corner_response.hovered() || corner_response.dragged() {
-                ui.ctx().set_cursor_icon(CursorIcon::ResizeNwSe);
+                let resize_cursor = match self.drag_corner {
+                    Align2::LEFT_TOP | Align2::RIGHT_BOTTOM => CursorIcon::ResizeNwSe,
+                    Align2::LEFT_BOTTOM | Align2::RIGHT_TOP => CursorIcon::ResizeNeSw,
+                    _ => panic!("Invalid corner alignment"),
+                };
+                ui.ctx().set_cursor_icon(resize_cursor);
             }
         }
 
@@ -375,9 +428,9 @@ impl Resize {
 
 use epaint::Stroke;
 
-pub fn paint_resize_corner(ui: &Ui, response: &Response) {
+pub fn paint_resize_corner(ui: &Ui, response: &Response, corner: Align2) {
     let stroke = ui.style().interact(response).fg_stroke;
-    paint_resize_corner_with_style(ui, &response.rect, stroke.color, Align2::RIGHT_BOTTOM);
+    paint_resize_corner_with_style(ui, &response.rect, stroke.color, corner);
 }
 
 pub fn paint_resize_corner_with_style(

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -1051,6 +1051,8 @@ impl Prepared {
 
             state.scroll_bar_interaction[d] = response.hovered() || response.dragged();
 
+            // MEMBRANE: Prevent dragging the scrollbar while resizing a side-panel right next to it.
+            // .filter(|_| response.dragged())
             if let Some(pointer_pos) = response.interact_pointer_pos() {
                 let scroll_start_offset_from_top_left = state.scroll_start_offset_from_top_left[d]
                     .get_or_insert_with(|| {

--- a/crates/egui/src/containers/scroll_area.rs
+++ b/crates/egui/src/containers/scroll_area.rs
@@ -572,10 +572,15 @@ impl ScrollArea {
             let mut content_clip_rect = ui.clip_rect();
             for d in 0..2 {
                 if scroll_enabled[d] {
-                    if state.content_is_too_large[d] {
-                        content_clip_rect.min[d] = inner_rect.min[d] - clip_rect_margin;
-                        content_clip_rect.max[d] = inner_rect.max[d] + clip_rect_margin;
-                    }
+                    // MEMBRANE: commenting out this check (which is an optimization anyway) because otherwise the
+                    // textarea cannot determine if `is_fully_visible` in the same frame it grows to be larger than the
+                    // scroll area. This was causing the cursor to not be reveled properly.
+                    // Additionally. This probably causes issues when the content of a scroll area grows from one frame
+                    // to the next, causing it to be unclipped for a frame.
+                    // if state.content_is_too_large[d] {
+                    content_clip_rect.min[d] = inner_rect.min[d] - clip_rect_margin;
+                    content_clip_rect.max[d] = inner_rect.max[d] + clip_rect_margin;
+                    // }
                 } else {
                     // Nice handling of forced resizing beyond the possible:
                     content_clip_rect.max[d] = ui.clip_rect().max[d] - current_bar_use[d];
@@ -1052,8 +1057,10 @@ impl Prepared {
             state.scroll_bar_interaction[d] = response.hovered() || response.dragged();
 
             // MEMBRANE: Prevent dragging the scrollbar while resizing a side-panel right next to it.
-            // .filter(|_| response.dragged())
-            if let Some(pointer_pos) = response.interact_pointer_pos() {
+            if let Some(pointer_pos) = response
+                .interact_pointer_pos()
+                .filter(|_| response.dragged())
+            {
                 let scroll_start_offset_from_top_left = state.scroll_start_offset_from_top_left[d]
                     .get_or_insert_with(|| {
                         if handle_rect.contains(pointer_pos) {
@@ -1101,16 +1108,16 @@ impl Prepared {
                         ),
                     )
                 };
+
+                // Ensure handle is not too small
                 let min_handle_size = scroll_style.handle_min_length;
-                if handle_rect.size()[d] < min_handle_size {
-                    handle_rect = Rect::from_center_size(
-                        handle_rect.center(),
-                        if d == 0 {
-                            vec2(min_handle_size, handle_rect.size().y)
-                        } else {
-                            vec2(handle_rect.size().x, min_handle_size)
-                        },
-                    );
+                let grow = min_handle_size - handle_rect.size()[d];
+                if grow > 0.0 {
+                    let how_scrolled = state.offset[d] / max_offset[d];
+                    let before = lerp(0.0..=grow, how_scrolled);
+                    let after = lerp(0.0..=grow, 1.0 - how_scrolled);
+                    handle_rect.min[d] -= before;
+                    handle_rect.max[d] += after;
                 }
 
                 let visuals = if scrolling_enabled {

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -436,9 +436,6 @@ impl<'open> Window<'open> {
         let mut window_frame = frame.unwrap_or_else(|| Frame::window(&ctx.style()));
         // Keep the original inner margin for later use
         let window_margin = window_frame.inner_margin;
-        let border_padding = window_frame.stroke.width / 2.0;
-        // Add border padding to the inner margin to prevent it from covering the contents
-        window_frame.inner_margin += border_padding;
 
         let is_explicitly_closed = matches!(open, Some(false));
         let is_open = !is_explicitly_closed || ctx.memory(|mem| mem.everything_is_visible());
@@ -572,9 +569,9 @@ impl<'open> Window<'open> {
 
             if let Some(title_bar) = title_bar {
                 let mut title_rect = Rect::from_min_size(
-                    outer_rect.min + vec2(border_padding, border_padding),
+                    outer_rect.min,
                     Vec2 {
-                        x: outer_rect.size().x - border_padding * 2.0,
+                        x: outer_rect.size().x,
                         y: title_bar_height,
                     },
                 );
@@ -583,9 +580,6 @@ impl<'open> Window<'open> {
 
                 if on_top && area_content_ui.visuals().window_highlight_topmost {
                     let mut round = window_frame.rounding;
-
-                    // Eliminate the rounding gap between the title bar and the window frame
-                    round -= border_padding;
 
                     if !is_collapsed {
                         round.se = 0.0;
@@ -600,7 +594,7 @@ impl<'open> Window<'open> {
 
                 // Fix title bar separator line position
                 if let Some(response) = &mut content_response {
-                    response.rect.min.y = outer_rect.min.y + title_bar_height + border_padding;
+                    response.rect.min.y = outer_rect.min.y + title_bar_height;
                 }
 
                 title_bar.ui(
@@ -664,14 +658,10 @@ fn paint_resize_corner(
         }
     };
 
-    // Adjust the corner offset to accommodate the stroke width and window rounding
-    let offset = if radius <= 2.0 && stroke.width < 2.0 {
-        2.0
-    } else {
-        // The corner offset is calculated to make the corner appear to be in the correct position
-        (2.0_f32.sqrt() * (1.0 + radius + stroke.width / 2.0) - radius)
-            * 45.0_f32.to_radians().cos()
-    };
+    // Adjust the corner offset to accommodate for window rounding
+    let offset =
+        ((2.0_f32.sqrt() * (1.0 + radius) - radius) * 45.0_f32.to_radians().cos()).max(2.0);
+
     let corner_size = Vec2::splat(ui.visuals().resize_corner_size);
     let corner_rect = corner.align_size_within_rect(corner_size, outer_rect);
     let corner_rect = corner_rect.translate(-offset * corner.to_sign()); // move away from corner
@@ -1133,7 +1123,6 @@ impl TitleBar {
         let text_pos =
             emath::align::center_size_in_rect(self.title_galley.size(), full_top_rect).left_top();
         let text_pos = text_pos - self.title_galley.rect.min.to_vec2();
-        let text_pos = text_pos - 1.5 * Vec2::Y; // HACK: center on x-height of text (looks better)
         ui.painter().galley(
             text_pos,
             self.title_galley.clone(),
@@ -1147,6 +1136,7 @@ impl TitleBar {
             let stroke = ui.visuals().widgets.noninteractive.bg_stroke;
             // Workaround: To prevent border infringement,
             // the 0.1 value should ideally be calculated using TessellationOptions::feathering_size_in_pixels
+            // or we could support selectively disabling feathering on line caps
             let x_range = outer_rect.x_range().shrink(0.1);
             ui.painter().hline(x_range, y, stroke);
         }

--- a/crates/egui/src/containers/window.rs
+++ b/crates/egui/src/containers/window.rs
@@ -467,7 +467,10 @@ impl<'open> Window<'open> {
         let (title_bar_height, title_content_spacing) = if with_title_bar {
             let style = ctx.style();
             let spacing = window_margin.top + window_margin.bottom;
-            let height = ctx.fonts(|f| title.font_height(f, &style)) + spacing;
+            let height = ctx
+                .fonts(|f| title.font_height(f, &style))
+                .max(ctx.style().spacing.interact_size.y)
+                + spacing;
             window_frame.rounding.ne = window_frame.rounding.ne.clamp(0.0, height / 2.0);
             window_frame.rounding.nw = window_frame.rounding.nw.clamp(0.0, height / 2.0);
             (height, spacing)
@@ -528,6 +531,7 @@ impl<'open> Window<'open> {
                 let title_bar = show_title_bar(
                     &mut frame.content_ui,
                     title,
+                    title_bar_height,
                     show_close_button,
                     &mut collapsing,
                     collapsible,
@@ -1033,14 +1037,12 @@ struct TitleBar {
 fn show_title_bar(
     ui: &mut Ui,
     title: WidgetText,
+    height: f32,
     show_close_button: bool,
     collapsing: &mut CollapsingState,
     collapsible: bool,
 ) -> TitleBar {
     let inner_response = ui.horizontal(|ui| {
-        let height = ui
-            .fonts(|fonts| title.font_height(fonts, ui.style()))
-            .max(ui.spacing().interact_size.y);
         ui.set_min_height(height);
 
         let item_spacing = ui.spacing().item_spacing;

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -335,6 +335,9 @@ struct ContextImpl {
   fonts: std::collections::BTreeMap<OrderedFloat<f32>, Fonts>,
   font_definitions: FontDefinitions,
 
+  /// MEMBRANE: increased each time the font atlas changes so we can drop any cached galleys.
+  font_generation: usize,
+
   memory: Memory,
   animation_manager: AnimationManager,
 
@@ -512,6 +515,7 @@ impl ContextImpl {
       #[cfg(feature = "log")]
       log::trace!("Creating new Fonts for pixels_per_point={pixels_per_point}");
 
+      self.font_generation += 1;
       is_new = true;
       crate::profile_scope!("Fonts::new");
       Fonts::new(pixels_per_point, max_texture_side, self.font_definitions.clone())
@@ -519,7 +523,9 @@ impl ContextImpl {
 
     {
       crate::profile_scope!("Fonts::begin_frame");
-      fonts.begin_frame(pixels_per_point, max_texture_side);
+      if fonts.begin_frame(pixels_per_point, max_texture_side) {
+        self.font_generation += 1;
+      }
     }
 
     if is_new && self.memory.options.preload_font_glyphs {

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3,23 +3,21 @@
 use std::{borrow::Cow, cell::RefCell, panic::Location, sync::Arc, time::Duration};
 
 use containers::area::AreaState;
-use epaint::{
-    emath::TSTransform, mutex::*, stats::*, text::Fonts, util::OrderedFloat, TessellationOptions, *,
-};
+use epaint::{emath::TSTransform, mutex::*, stats::*, text::Fonts, util::OrderedFloat, TessellationOptions, *};
 
 use crate::{
-    animation_manager::AnimationManager,
-    data::output::PlatformOutput,
-    frame_state::FrameState,
-    input_state::*,
-    layers::GraphicLayers,
-    load::{Bytes, Loaders, SizedTexture},
-    memory::Options,
-    os::OperatingSystem,
-    output::FullOutput,
-    util::IdTypeMap,
-    viewport::ViewportClass,
-    TextureHandle, ViewportCommand, *,
+  animation_manager::AnimationManager,
+  data::output::PlatformOutput,
+  frame_state::FrameState,
+  input_state::*,
+  layers::GraphicLayers,
+  load::{Bytes, Loaders, SizedTexture},
+  memory::Options,
+  os::OperatingSystem,
+  output::FullOutput,
+  util::IdTypeMap,
+  viewport::ViewportClass,
+  TextureHandle, ViewportCommand, *,
 };
 
 use self::{hit_test::WidgetHits, interaction::InteractionSnapshot};
@@ -29,17 +27,17 @@ use self::{hit_test::WidgetHits, interaction::InteractionSnapshot};
 /// This is given in the callback set by [`Context::set_request_repaint_callback`].
 #[derive(Clone, Copy, Debug)]
 pub struct RequestRepaintInfo {
-    /// This is used to specify what viewport that should repaint.
-    pub viewport_id: ViewportId,
+  /// This is used to specify what viewport that should repaint.
+  pub viewport_id: ViewportId,
 
-    /// Repaint after this duration. If zero, repaint as soon as possible.
-    pub delay: Duration,
+  /// Repaint after this duration. If zero, repaint as soon as possible.
+  pub delay: Duration,
 
-    /// The current frame number.
-    ///
-    /// This can be compared to [`Context::frame_nr`] to see if we've already
-    /// triggered the painting of the next frame.
-    pub current_frame_nr: u64,
+  /// The current frame number.
+  ///
+  /// This can be compared to [`Context::frame_nr`] to see if we've already
+  /// triggered the painting of the next frame.
+  pub current_frame_nr: u64,
 }
 
 // ----------------------------------------------------------------------------
@@ -53,19 +51,15 @@ thread_local! {
 struct WrappedTextureManager(Arc<RwLock<epaint::TextureManager>>);
 
 impl Default for WrappedTextureManager {
-    fn default() -> Self {
-        let mut tex_mngr = epaint::textures::TextureManager::default();
+  fn default() -> Self {
+    let mut tex_mngr = epaint::textures::TextureManager::default();
 
-        // Will be filled in later
-        let font_id = tex_mngr.alloc(
-            "egui_font_texture".into(),
-            epaint::FontImage::new([0, 0]).into(),
-            Default::default(),
-        );
-        assert_eq!(font_id, TextureId::default());
+    // Will be filled in later
+    let font_id = tex_mngr.alloc("egui_font_texture".into(), epaint::FontImage::new([0, 0]).into(), Default::default());
+    assert_eq!(font_id, TextureId::default());
 
-        Self(Arc::new(RwLock::new(tex_mngr)))
-    }
+    Self(Arc::new(RwLock::new(tex_mngr)))
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -75,130 +69,113 @@ pub type ContextCallback = Arc<dyn Fn(&Context) + Send + Sync>;
 
 #[derive(Clone)]
 struct NamedContextCallback {
-    debug_name: &'static str,
-    callback: ContextCallback,
+  debug_name: &'static str,
+  callback: ContextCallback,
 }
 
 /// Callbacks that users can register
 #[derive(Clone, Default)]
 struct Plugins {
-    pub on_begin_frame: Vec<NamedContextCallback>,
-    pub on_end_frame: Vec<NamedContextCallback>,
+  pub on_begin_frame: Vec<NamedContextCallback>,
+  pub on_end_frame: Vec<NamedContextCallback>,
 }
 
 impl Plugins {
-    fn call(ctx: &Context, _cb_name: &str, callbacks: &[NamedContextCallback]) {
-        crate::profile_scope!("plugins", _cb_name);
-        for NamedContextCallback {
-            debug_name: _name,
-            callback,
-        } in callbacks
-        {
-            crate::profile_scope!("plugin", _name);
-            (callback)(ctx);
-        }
+  fn call(ctx: &Context, _cb_name: &str, callbacks: &[NamedContextCallback]) {
+    crate::profile_scope!("plugins", _cb_name);
+    for NamedContextCallback { debug_name: _name, callback } in callbacks {
+      crate::profile_scope!("plugin", _name);
+      (callback)(ctx);
     }
+  }
 
-    fn on_begin_frame(&self, ctx: &Context) {
-        Self::call(ctx, "on_begin_frame", &self.on_begin_frame);
-    }
+  fn on_begin_frame(&self, ctx: &Context) {
+    Self::call(ctx, "on_begin_frame", &self.on_begin_frame);
+  }
 
-    fn on_end_frame(&self, ctx: &Context) {
-        Self::call(ctx, "on_end_frame", &self.on_end_frame);
-    }
+  fn on_end_frame(&self, ctx: &Context) {
+    Self::call(ctx, "on_end_frame", &self.on_end_frame);
+  }
 }
 
 // ----------------------------------------------------------------------------
 
 /// Repaint-logic
 impl ContextImpl {
-    /// This is where we update the repaint logic.
-    fn begin_frame_repaint_logic(&mut self, viewport_id: ViewportId) {
-        let viewport = self.viewports.entry(viewport_id).or_default();
+  /// This is where we update the repaint logic.
+  fn begin_frame_repaint_logic(&mut self, viewport_id: ViewportId) {
+    let viewport = self.viewports.entry(viewport_id).or_default();
 
-        std::mem::swap(
-            &mut viewport.repaint.prev_causes,
-            &mut viewport.repaint.causes,
-        );
-        viewport.repaint.causes.clear();
+    std::mem::swap(&mut viewport.repaint.prev_causes, &mut viewport.repaint.causes);
+    viewport.repaint.causes.clear();
 
-        viewport.repaint.prev_frame_paint_delay = viewport.repaint.repaint_delay;
+    viewport.repaint.prev_frame_paint_delay = viewport.repaint.repaint_delay;
 
-        if viewport.repaint.outstanding == 0 {
-            // We are repainting now, so we can wait a while for the next repaint.
-            viewport.repaint.repaint_delay = Duration::MAX;
-        } else {
-            viewport.repaint.repaint_delay = Duration::ZERO;
-            viewport.repaint.outstanding -= 1;
-            if let Some(callback) = &self.request_repaint_callback {
-                (callback)(RequestRepaintInfo {
-                    viewport_id,
-                    delay: Duration::ZERO,
-                    current_frame_nr: viewport.repaint.frame_nr,
-                });
-            }
-        }
+    if viewport.repaint.outstanding == 0 {
+      // We are repainting now, so we can wait a while for the next repaint.
+      viewport.repaint.repaint_delay = Duration::MAX;
+    } else {
+      viewport.repaint.repaint_delay = Duration::ZERO;
+      viewport.repaint.outstanding -= 1;
+      if let Some(callback) = &self.request_repaint_callback {
+        (callback)(RequestRepaintInfo {
+          viewport_id,
+          delay: Duration::ZERO,
+          current_frame_nr: viewport.repaint.frame_nr,
+        });
+      }
+    }
+  }
+
+  fn request_repaint(&mut self, viewport_id: ViewportId, cause: RepaintCause) {
+    self.request_repaint_after(Duration::ZERO, viewport_id, cause);
+  }
+
+  fn request_repaint_after(&mut self, mut delay: Duration, viewport_id: ViewportId, cause: RepaintCause) {
+    let viewport = self.viewports.entry(viewport_id).or_default();
+
+    if delay == Duration::ZERO {
+      // Each request results in two repaints, just to give some things time to settle.
+      // This solves some corner-cases of missing repaints on frame-delayed responses.
+      viewport.repaint.outstanding = 1;
+    } else {
+      // For non-zero delays, we only repaint once, because
+      // otherwise we would just schedule an immediate repaint _now_,
+      // which would then clear the delay and repaint again.
+      // Hovering a tooltip is a good example of a case where we want to repaint after a delay.
     }
 
-    fn request_repaint(&mut self, viewport_id: ViewportId, cause: RepaintCause) {
-        self.request_repaint_after(Duration::ZERO, viewport_id, cause);
+    if let Ok(predicted_frame_time) = Duration::try_from_secs_f32(viewport.input.predicted_dt) {
+      // Make it less likely we over-shoot the target:
+      delay = delay.saturating_sub(predicted_frame_time);
     }
 
-    fn request_repaint_after(
-        &mut self,
-        mut delay: Duration,
-        viewport_id: ViewportId,
-        cause: RepaintCause,
-    ) {
-        let viewport = self.viewports.entry(viewport_id).or_default();
+    viewport.repaint.causes.push(cause);
 
-        if delay == Duration::ZERO {
-            // Each request results in two repaints, just to give some things time to settle.
-            // This solves some corner-cases of missing repaints on frame-delayed responses.
-            viewport.repaint.outstanding = 1;
-        } else {
-            // For non-zero delays, we only repaint once, because
-            // otherwise we would just schedule an immediate repaint _now_,
-            // which would then clear the delay and repaint again.
-            // Hovering a tooltip is a good example of a case where we want to repaint after a delay.
-        }
+    // We save some CPU time by only calling the callback if we need to.
+    // If the new delay is greater or equal to the previous lowest,
+    // it means we have already called the callback, and don't need to do it again.
+    if delay < viewport.repaint.repaint_delay {
+      viewport.repaint.repaint_delay = delay;
 
-        if let Ok(predicted_frame_time) = Duration::try_from_secs_f32(viewport.input.predicted_dt) {
-            // Make it less likely we over-shoot the target:
-            delay = delay.saturating_sub(predicted_frame_time);
-        }
-
-        viewport.repaint.causes.push(cause);
-
-        // We save some CPU time by only calling the callback if we need to.
-        // If the new delay is greater or equal to the previous lowest,
-        // it means we have already called the callback, and don't need to do it again.
-        if delay < viewport.repaint.repaint_delay {
-            viewport.repaint.repaint_delay = delay;
-
-            if let Some(callback) = &self.request_repaint_callback {
-                (callback)(RequestRepaintInfo {
-                    viewport_id,
-                    delay,
-                    current_frame_nr: viewport.repaint.frame_nr,
-                });
-            }
-        }
+      if let Some(callback) = &self.request_repaint_callback {
+        (callback)(RequestRepaintInfo { viewport_id, delay, current_frame_nr: viewport.repaint.frame_nr });
+      }
     }
+  }
 
-    #[must_use]
-    fn requested_immediate_repaint_prev_frame(&self, viewport_id: &ViewportId) -> bool {
-        self.viewports.get(viewport_id).map_or(false, |v| {
-            v.repaint.requested_immediate_repaint_prev_frame()
-        })
-    }
+  #[must_use]
+  fn requested_immediate_repaint_prev_frame(&self, viewport_id: &ViewportId) -> bool {
+    self.viewports.get(viewport_id).map_or(false, |v| v.repaint.requested_immediate_repaint_prev_frame())
+  }
 
-    #[must_use]
-    fn has_requested_repaint(&self, viewport_id: &ViewportId) -> bool {
-        self.viewports.get(viewport_id).map_or(false, |v| {
-            0 < v.repaint.outstanding || v.repaint.repaint_delay < Duration::MAX
-        })
-    }
+  #[must_use]
+  fn has_requested_repaint(&self, viewport_id: &ViewportId) -> bool {
+    self
+      .viewports
+      .get(viewport_id)
+      .map_or(false, |v| 0 < v.repaint.outstanding || v.repaint.repaint_delay < Duration::MAX)
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -209,423 +186,396 @@ impl ContextImpl {
 /// Things here may move and change without warning.
 #[derive(Default)]
 pub struct ViewportState {
-    /// The type of viewport.
-    ///
-    /// This will never be [`ViewportClass::Embedded`],
-    /// since those don't result in real viewports.
-    pub class: ViewportClass,
+  /// The type of viewport.
+  ///
+  /// This will never be [`ViewportClass::Embedded`],
+  /// since those don't result in real viewports.
+  pub class: ViewportClass,
 
-    /// The latest delta
-    pub builder: ViewportBuilder,
+  /// The latest delta
+  pub builder: ViewportBuilder,
 
-    /// The user-code that shows the GUI, used for deferred viewports.
-    ///
-    /// `None` for immediate viewports.
-    pub viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
+  /// The user-code that shows the GUI, used for deferred viewports.
+  ///
+  /// `None` for immediate viewports.
+  pub viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
 
-    pub input: InputState,
+  pub input: InputState,
 
-    /// State that is collected during a frame and then cleared.
-    pub this_frame: FrameState,
+  /// State that is collected during a frame and then cleared.
+  pub this_frame: FrameState,
 
-    /// The final [`FrameState`] from last frame.
-    ///
-    /// Only read from.
-    pub prev_frame: FrameState,
+  /// The final [`FrameState`] from last frame.
+  ///
+  /// Only read from.
+  pub prev_frame: FrameState,
 
-    /// Has this viewport been updated this frame?
-    pub used: bool,
+  /// Has this viewport been updated this frame?
+  pub used: bool,
 
-    /// State related to repaint scheduling.
-    repaint: ViewportRepaintInfo,
+  /// State related to repaint scheduling.
+  repaint: ViewportRepaintInfo,
 
-    // ----------------------
-    // Updated at the start of the frame:
-    //
-    /// Which widgets are under the pointer?
-    pub hits: WidgetHits,
+  // ----------------------
+  // Updated at the start of the frame:
+  //
+  /// Which widgets are under the pointer?
+  pub hits: WidgetHits,
 
-    /// What widgets are being interacted with this frame?
-    ///
-    /// Based on the widgets from last frame, and input in this frame.
-    pub interact_widgets: InteractionSnapshot,
+  /// What widgets are being interacted with this frame?
+  ///
+  /// Based on the widgets from last frame, and input in this frame.
+  pub interact_widgets: InteractionSnapshot,
 
-    // ----------------------
-    // The output of a frame:
-    //
-    pub graphics: GraphicLayers,
-    // Most of the things in `PlatformOutput` are not actually viewport dependent.
-    pub output: PlatformOutput,
-    pub commands: Vec<ViewportCommand>,
+  // ----------------------
+  // The output of a frame:
+  //
+  pub graphics: GraphicLayers,
+  // Most of the things in `PlatformOutput` are not actually viewport dependent.
+  pub output: PlatformOutput,
+  pub commands: Vec<ViewportCommand>,
 }
 
 /// What called [`Context::request_repaint`]?
 #[derive(Clone)]
 pub struct RepaintCause {
-    /// What file had the call that requested the repaint?
-    pub file: &'static str,
+  /// What file had the call that requested the repaint?
+  pub file: &'static str,
 
-    /// What line number of the call that requested the repaint?
-    pub line: u32,
+  /// What line number of the call that requested the repaint?
+  pub line: u32,
 }
 
 impl std::fmt::Debug for RepaintCause {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.file, self.line)
-    }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}:{}", self.file, self.line)
+  }
 }
 
 impl RepaintCause {
-    /// Capture the file and line number of the call site.
-    #[allow(clippy::new_without_default)]
-    #[track_caller]
-    pub fn new() -> Self {
-        let caller = Location::caller();
-        Self {
-            file: caller.file(),
-            line: caller.line(),
-        }
-    }
+  /// Capture the file and line number of the call site.
+  #[allow(clippy::new_without_default)]
+  #[track_caller]
+  pub fn new() -> Self {
+    let caller = Location::caller();
+    Self { file: caller.file(), line: caller.line() }
+  }
 }
 
 impl std::fmt::Display for RepaintCause {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.file, self.line)
-    }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}:{}", self.file, self.line)
+  }
 }
 
 /// Per-viewport state related to repaint scheduling.
 struct ViewportRepaintInfo {
-    /// Monotonically increasing counter.
-    frame_nr: u64,
+  /// Monotonically increasing counter.
+  frame_nr: u64,
 
-    /// The duration which the backend will poll for new events
-    /// before forcing another egui update, even if there's no new events.
-    ///
-    /// Also used to suppress multiple calls to the repaint callback during the same frame.
-    ///
-    /// This is also returned in [`crate::ViewportOutput`].
-    repaint_delay: Duration,
+  /// The duration which the backend will poll for new events
+  /// before forcing another egui update, even if there's no new events.
+  ///
+  /// Also used to suppress multiple calls to the repaint callback during the same frame.
+  ///
+  /// This is also returned in [`crate::ViewportOutput`].
+  repaint_delay: Duration,
 
-    /// While positive, keep requesting repaints. Decrement at the start of each frame.
-    outstanding: u8,
+  /// While positive, keep requesting repaints. Decrement at the start of each frame.
+  outstanding: u8,
 
-    /// What caused repaints during this frame?
-    causes: Vec<RepaintCause>,
+  /// What caused repaints during this frame?
+  causes: Vec<RepaintCause>,
 
-    /// What triggered a repaint the previous frame?
-    /// (i.e: why are we updating now?)
-    prev_causes: Vec<RepaintCause>,
+  /// What triggered a repaint the previous frame?
+  /// (i.e: why are we updating now?)
+  prev_causes: Vec<RepaintCause>,
 
-    /// What was the output of `repaint_delay` on the previous frame?
-    ///
-    /// If this was zero, we are repainting as quickly as possible
-    /// (as far as we know).
-    prev_frame_paint_delay: Duration,
+  /// What was the output of `repaint_delay` on the previous frame?
+  ///
+  /// If this was zero, we are repainting as quickly as possible
+  /// (as far as we know).
+  prev_frame_paint_delay: Duration,
 }
 
 impl Default for ViewportRepaintInfo {
-    fn default() -> Self {
-        Self {
-            frame_nr: 0,
+  fn default() -> Self {
+    Self {
+      frame_nr: 0,
 
-            // We haven't scheduled a repaint yet.
-            repaint_delay: Duration::MAX,
+      // We haven't scheduled a repaint yet.
+      repaint_delay: Duration::MAX,
 
-            // Let's run a couple of frames at the start, because why not.
-            outstanding: 1,
+      // Let's run a couple of frames at the start, because why not.
+      outstanding: 1,
 
-            causes: Default::default(),
-            prev_causes: Default::default(),
+      causes: Default::default(),
+      prev_causes: Default::default(),
 
-            prev_frame_paint_delay: Duration::MAX,
-        }
+      prev_frame_paint_delay: Duration::MAX,
     }
+  }
 }
 
 impl ViewportRepaintInfo {
-    pub fn requested_immediate_repaint_prev_frame(&self) -> bool {
-        self.prev_frame_paint_delay == Duration::ZERO
-    }
+  pub fn requested_immediate_repaint_prev_frame(&self) -> bool {
+    self.prev_frame_paint_delay == Duration::ZERO
+  }
 }
 
 // ----------------------------------------------------------------------------
 
 #[derive(Default)]
 struct ContextImpl {
-    /// Since we could have multiple viewports across multiple monitors with
-    /// different `pixels_per_point`, we need a `Fonts` instance for each unique
-    /// `pixels_per_point`.
-    /// This is because the `Fonts` depend on `pixels_per_point` for the font atlas
-    /// as well as kerning, font sizes, etc.
-    fonts: std::collections::BTreeMap<OrderedFloat<f32>, Fonts>,
-    font_definitions: FontDefinitions,
+  /// Since we could have multiple viewports across multiple monitors with
+  /// different `pixels_per_point`, we need a `Fonts` instance for each unique
+  /// `pixels_per_point`.
+  /// This is because the `Fonts` depend on `pixels_per_point` for the font atlas
+  /// as well as kerning, font sizes, etc.
+  fonts: std::collections::BTreeMap<OrderedFloat<f32>, Fonts>,
+  font_definitions: FontDefinitions,
 
-    memory: Memory,
-    animation_manager: AnimationManager,
+  memory: Memory,
+  animation_manager: AnimationManager,
 
-    plugins: Plugins,
+  plugins: Plugins,
 
-    /// All viewports share the same texture manager and texture namespace.
-    ///
-    /// In all viewports, [`TextureId::default`] is special, and points to the font atlas.
-    /// The font-atlas texture _may_ be different across viewports, as they may have different
-    /// `pixels_per_point`, so we do special book-keeping for that.
-    /// See <https://github.com/emilk/egui/issues/3664>.
-    tex_manager: WrappedTextureManager,
+  /// All viewports share the same texture manager and texture namespace.
+  ///
+  /// In all viewports, [`TextureId::default`] is special, and points to the font atlas.
+  /// The font-atlas texture _may_ be different across viewports, as they may have different
+  /// `pixels_per_point`, so we do special book-keeping for that.
+  /// See <https://github.com/emilk/egui/issues/3664>.
+  tex_manager: WrappedTextureManager,
 
-    /// Set during the frame, becomes active at the start of the next frame.
-    new_zoom_factor: Option<f32>,
+  /// Set during the frame, becomes active at the start of the next frame.
+  new_zoom_factor: Option<f32>,
 
-    os: OperatingSystem,
+  os: OperatingSystem,
 
-    /// How deeply nested are we?
-    viewport_stack: Vec<ViewportIdPair>,
+  /// How deeply nested are we?
+  viewport_stack: Vec<ViewportIdPair>,
 
-    /// What is the last viewport rendered?
-    last_viewport: ViewportId,
+  /// What is the last viewport rendered?
+  last_viewport: ViewportId,
 
-    paint_stats: PaintStats,
+  paint_stats: PaintStats,
 
-    request_repaint_callback: Option<Box<dyn Fn(RequestRepaintInfo) + Send + Sync>>,
+  request_repaint_callback: Option<Box<dyn Fn(RequestRepaintInfo) + Send + Sync>>,
 
-    viewport_parents: ViewportIdMap<ViewportId>,
-    viewports: ViewportIdMap<ViewportState>,
+  viewport_parents: ViewportIdMap<ViewportId>,
+  viewports: ViewportIdMap<ViewportState>,
 
-    embed_viewports: bool,
+  embed_viewports: bool,
 
-    #[cfg(feature = "accesskit")]
-    is_accesskit_enabled: bool,
-    #[cfg(feature = "accesskit")]
-    accesskit_node_classes: accesskit::NodeClassSet,
+  #[cfg(feature = "accesskit")]
+  is_accesskit_enabled: bool,
+  #[cfg(feature = "accesskit")]
+  accesskit_node_classes: accesskit::NodeClassSet,
 
-    loaders: Arc<Loaders>,
+  loaders: Arc<Loaders>,
 }
 
 impl ContextImpl {
-    fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
-        let viewport_id = new_raw_input.viewport_id;
-        let parent_id = new_raw_input
-            .viewports
-            .get(&viewport_id)
-            .and_then(|v| v.parent)
-            .unwrap_or_default();
-        let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent_id);
+  fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
+    let viewport_id = new_raw_input.viewport_id;
+    let parent_id = new_raw_input.viewports.get(&viewport_id).and_then(|v| v.parent).unwrap_or_default();
+    let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent_id);
 
-        let is_outermost_viewport = self.viewport_stack.is_empty(); // not necessarily root, just outermost immediate viewport
-        self.viewport_stack.push(ids);
+    let is_outermost_viewport = self.viewport_stack.is_empty(); // not necessarily root, just outermost immediate viewport
+    self.viewport_stack.push(ids);
 
-        self.begin_frame_repaint_logic(viewport_id);
+    self.begin_frame_repaint_logic(viewport_id);
 
-        let viewport = self.viewports.entry(viewport_id).or_default();
+    let viewport = self.viewports.entry(viewport_id).or_default();
 
-        if is_outermost_viewport {
-            if let Some(new_zoom_factor) = self.new_zoom_factor.take() {
-                let ratio = self.memory.options.zoom_factor / new_zoom_factor;
-                self.memory.options.zoom_factor = new_zoom_factor;
+    if is_outermost_viewport {
+      if let Some(new_zoom_factor) = self.new_zoom_factor.take() {
+        let ratio = self.memory.options.zoom_factor / new_zoom_factor;
+        self.memory.options.zoom_factor = new_zoom_factor;
 
-                let input = &viewport.input;
-                // This is a bit hacky, but is required to avoid jitter:
-                let mut rect = input.screen_rect;
-                rect.min = (ratio * rect.min.to_vec2()).to_pos2();
-                rect.max = (ratio * rect.max.to_vec2()).to_pos2();
-                new_raw_input.screen_rect = Some(rect);
-                // We should really scale everything else in the input too,
-                // but the `screen_rect` is the most important part.
-            }
+        let input = &viewport.input;
+        // This is a bit hacky, but is required to avoid jitter:
+        let mut rect = input.screen_rect;
+        rect.min = (ratio * rect.min.to_vec2()).to_pos2();
+        rect.max = (ratio * rect.max.to_vec2()).to_pos2();
+        new_raw_input.screen_rect = Some(rect);
+        // We should really scale everything else in the input too,
+        // but the `screen_rect` is the most important part.
+      }
+    }
+    let native_pixels_per_point = new_raw_input.viewport().native_pixels_per_point.unwrap_or(1.0);
+    let pixels_per_point = self.memory.options.zoom_factor * native_pixels_per_point;
+
+    let all_viewport_ids: ViewportIdSet = self.all_viewport_ids();
+
+    let viewport = self.viewports.entry(self.viewport_id()).or_default();
+
+    self.memory.begin_frame(&new_raw_input, &all_viewport_ids);
+
+    viewport.input = std::mem::take(&mut viewport.input).begin_frame(
+      new_raw_input,
+      viewport.repaint.requested_immediate_repaint_prev_frame(),
+      pixels_per_point,
+      &self.memory.options,
+    );
+
+    let screen_rect = viewport.input.screen_rect;
+
+    viewport.this_frame.begin_frame(screen_rect);
+
+    {
+      let area_order = self.memory.areas().order_map();
+
+      let mut layers: Vec<LayerId> = viewport.prev_frame.widgets.layer_ids().collect();
+
+      layers.sort_by(|a, b| {
+        if a.order == b.order {
+          // Maybe both are windows, so respect area order:
+          area_order.get(a).cmp(&area_order.get(b))
+        } else {
+          // comparing e.g. background to tooltips
+          a.order.cmp(&b.order)
         }
-        let native_pixels_per_point = new_raw_input
-            .viewport()
-            .native_pixels_per_point
-            .unwrap_or(1.0);
-        let pixels_per_point = self.memory.options.zoom_factor * native_pixels_per_point;
+      });
 
-        let all_viewport_ids: ViewportIdSet = self.all_viewport_ids();
+      viewport.hits = if let Some(pos) = viewport.input.pointer.interact_pos() {
+        let interact_radius = self.memory.options.style.interaction.interact_radius;
 
-        let viewport = self.viewports.entry(self.viewport_id()).or_default();
+        crate::hit_test::hit_test(
+          &viewport.prev_frame.widgets,
+          &layers,
+          &self.memory.layer_transforms,
+          pos,
+          interact_radius,
+        )
+      } else {
+        WidgetHits::default()
+      };
 
-        self.memory.begin_frame(&new_raw_input, &all_viewport_ids);
-
-        viewport.input = std::mem::take(&mut viewport.input).begin_frame(
-            new_raw_input,
-            viewport.repaint.requested_immediate_repaint_prev_frame(),
-            pixels_per_point,
-            &self.memory.options,
-        );
-
-        let screen_rect = viewport.input.screen_rect;
-
-        viewport.this_frame.begin_frame(screen_rect);
-
-        {
-            let area_order = self.memory.areas().order_map();
-
-            let mut layers: Vec<LayerId> = viewport.prev_frame.widgets.layer_ids().collect();
-
-            layers.sort_by(|a, b| {
-                if a.order == b.order {
-                    // Maybe both are windows, so respect area order:
-                    area_order.get(a).cmp(&area_order.get(b))
-                } else {
-                    // comparing e.g. background to tooltips
-                    a.order.cmp(&b.order)
-                }
-            });
-
-            viewport.hits = if let Some(pos) = viewport.input.pointer.interact_pos() {
-                let interact_radius = self.memory.options.style.interaction.interact_radius;
-
-                crate::hit_test::hit_test(
-                    &viewport.prev_frame.widgets,
-                    &layers,
-                    &self.memory.layer_transforms,
-                    pos,
-                    interact_radius,
-                )
-            } else {
-                WidgetHits::default()
-            };
-
-            viewport.interact_widgets = crate::interaction::interact(
-                &viewport.interact_widgets,
-                &viewport.prev_frame.widgets,
-                &viewport.hits,
-                &viewport.input,
-                self.memory.interaction_mut(),
-            );
-        }
-
-        // Ensure we register the background area so panels and background ui can catch clicks:
-        self.memory.areas_mut().set_state(
-            LayerId::background(),
-            AreaState {
-                pivot_pos: Some(screen_rect.left_top()),
-                pivot: Align2::LEFT_TOP,
-                size: Some(screen_rect.size()),
-                interactable: true,
-                last_became_visible_at: None,
-            },
-        );
-
-        #[cfg(feature = "accesskit")]
-        if self.is_accesskit_enabled {
-            crate::profile_scope!("accesskit");
-            use crate::frame_state::AccessKitFrameState;
-            let id = crate::accesskit_root_id();
-            let mut builder = accesskit::NodeBuilder::new(accesskit::Role::Window);
-            let pixels_per_point = viewport.input.pixels_per_point();
-            builder.set_transform(accesskit::Affine::scale(pixels_per_point.into()));
-            let mut node_builders = IdMap::default();
-            node_builders.insert(id, builder);
-            viewport.this_frame.accesskit_state = Some(AccessKitFrameState {
-                node_builders,
-                parent_stack: vec![id],
-            });
-        }
-
-        self.update_fonts_mut();
+      viewport.interact_widgets = crate::interaction::interact(
+        &viewport.interact_widgets,
+        &viewport.prev_frame.widgets,
+        &viewport.hits,
+        &viewport.input,
+        self.memory.interaction_mut(),
+      );
     }
 
-    /// Load fonts unless already loaded.
-    fn update_fonts_mut(&mut self) {
-        crate::profile_function!();
-
-        let input = &self.viewport().input;
-        let pixels_per_point = input.pixels_per_point();
-        let max_texture_side = input.max_texture_side;
-
-        if let Some(font_definitions) = self.memory.new_font_definitions.take() {
-            // New font definition loaded, so we need to reload all fonts.
-            self.fonts.clear();
-            self.font_definitions = font_definitions;
-            #[cfg(feature = "log")]
-            log::debug!("Loading new font definitions");
-        }
-
-        let mut is_new = false;
-
-        let fonts = self
-            .fonts
-            .entry(pixels_per_point.into())
-            .or_insert_with(|| {
-                #[cfg(feature = "log")]
-                log::trace!("Creating new Fonts for pixels_per_point={pixels_per_point}");
-
-                is_new = true;
-                crate::profile_scope!("Fonts::new");
-                Fonts::new(
-                    pixels_per_point,
-                    max_texture_side,
-                    self.font_definitions.clone(),
-                )
-            });
-
-        {
-            crate::profile_scope!("Fonts::begin_frame");
-            fonts.begin_frame(pixels_per_point, max_texture_side);
-        }
-
-        if is_new && self.memory.options.preload_font_glyphs {
-            crate::profile_scope!("preload_font_glyphs");
-            // Preload the most common characters for the most common fonts.
-            // This is not very important to do, but may save a few GPU operations.
-            for font_id in self.memory.options.style.text_styles.values() {
-                fonts.lock().fonts.font(font_id).preload_common_characters();
-            }
-        }
-    }
+    // Ensure we register the background area so panels and background ui can catch clicks:
+    self.memory.areas_mut().set_state(
+      LayerId::background(),
+      AreaState {
+        pivot_pos: Some(screen_rect.left_top()),
+        pivot: Align2::LEFT_TOP,
+        size: Some(screen_rect.size()),
+        interactable: true,
+        last_became_visible_at: None,
+      },
+    );
 
     #[cfg(feature = "accesskit")]
-    fn accesskit_node_builder(&mut self, id: Id) -> &mut accesskit::NodeBuilder {
-        let state = self.viewport().this_frame.accesskit_state.as_mut().unwrap();
-        let builders = &mut state.node_builders;
-        if let std::collections::hash_map::Entry::Vacant(entry) = builders.entry(id) {
-            entry.insert(Default::default());
-            let parent_id = state.parent_stack.last().unwrap();
-            let parent_builder = builders.get_mut(parent_id).unwrap();
-            parent_builder.push_child(id.accesskit_id());
-        }
-        builders.get_mut(&id).unwrap()
+    if self.is_accesskit_enabled {
+      crate::profile_scope!("accesskit");
+      use crate::frame_state::AccessKitFrameState;
+      let id = crate::accesskit_root_id();
+      let mut builder = accesskit::NodeBuilder::new(accesskit::Role::Window);
+      let pixels_per_point = viewport.input.pixels_per_point();
+      builder.set_transform(accesskit::Affine::scale(pixels_per_point.into()));
+      let mut node_builders = IdMap::default();
+      node_builders.insert(id, builder);
+      viewport.this_frame.accesskit_state = Some(AccessKitFrameState { node_builders, parent_stack: vec![id] });
     }
 
-    fn pixels_per_point(&mut self) -> f32 {
-        self.viewport().input.pixels_per_point
+    self.update_fonts_mut();
+  }
+
+  /// Load fonts unless already loaded.
+  fn update_fonts_mut(&mut self) {
+    crate::profile_function!();
+
+    let input = &self.viewport().input;
+    let pixels_per_point = input.pixels_per_point();
+    let max_texture_side = input.max_texture_side;
+
+    if let Some(font_definitions) = self.memory.new_font_definitions.take() {
+      // New font definition loaded, so we need to reload all fonts.
+      self.fonts.clear();
+      self.font_definitions = font_definitions;
+      #[cfg(feature = "log")]
+      log::debug!("Loading new font definitions");
     }
 
-    /// Return the `ViewportId` of the current viewport.
-    ///
-    /// For the root viewport this will return [`ViewportId::ROOT`].
-    pub(crate) fn viewport_id(&self) -> ViewportId {
-        self.viewport_stack.last().copied().unwrap_or_default().this
+    let mut is_new = false;
+
+    let fonts = self.fonts.entry(pixels_per_point.into()).or_insert_with(|| {
+      #[cfg(feature = "log")]
+      log::trace!("Creating new Fonts for pixels_per_point={pixels_per_point}");
+
+      is_new = true;
+      crate::profile_scope!("Fonts::new");
+      Fonts::new(pixels_per_point, max_texture_side, self.font_definitions.clone())
+    });
+
+    {
+      crate::profile_scope!("Fonts::begin_frame");
+      fonts.begin_frame(pixels_per_point, max_texture_side);
     }
 
-    /// Return the `ViewportId` of his parent.
-    ///
-    /// For the root viewport this will return [`ViewportId::ROOT`].
-    pub(crate) fn parent_viewport_id(&self) -> ViewportId {
-        let viewport_id = self.viewport_id();
-        *self
-            .viewport_parents
-            .get(&viewport_id)
-            .unwrap_or(&ViewportId::ROOT)
+    if is_new && self.memory.options.preload_font_glyphs {
+      crate::profile_scope!("preload_font_glyphs");
+      // Preload the most common characters for the most common fonts.
+      // This is not very important to do, but may save a few GPU operations.
+      for font_id in self.memory.options.style.text_styles.values() {
+        fonts.lock().fonts.font(font_id).preload_common_characters();
+      }
     }
+  }
 
-    fn all_viewport_ids(&self) -> ViewportIdSet {
-        self.viewports
-            .keys()
-            .copied()
-            .chain([ViewportId::ROOT])
-            .collect()
+  #[cfg(feature = "accesskit")]
+  fn accesskit_node_builder(&mut self, id: Id) -> &mut accesskit::NodeBuilder {
+    let state = self.viewport().this_frame.accesskit_state.as_mut().unwrap();
+    let builders = &mut state.node_builders;
+    if let std::collections::hash_map::Entry::Vacant(entry) = builders.entry(id) {
+      entry.insert(Default::default());
+      let parent_id = state.parent_stack.last().unwrap();
+      let parent_builder = builders.get_mut(parent_id).unwrap();
+      parent_builder.push_child(id.accesskit_id());
     }
+    builders.get_mut(&id).unwrap()
+  }
 
-    /// The current active viewport
-    pub(crate) fn viewport(&mut self) -> &mut ViewportState {
-        self.viewports.entry(self.viewport_id()).or_default()
-    }
+  fn pixels_per_point(&mut self) -> f32 {
+    self.viewport().input.pixels_per_point
+  }
 
-    fn viewport_for(&mut self, viewport_id: ViewportId) -> &mut ViewportState {
-        self.viewports.entry(viewport_id).or_default()
-    }
+  /// Return the `ViewportId` of the current viewport.
+  ///
+  /// For the root viewport this will return [`ViewportId::ROOT`].
+  pub(crate) fn viewport_id(&self) -> ViewportId {
+    self.viewport_stack.last().copied().unwrap_or_default().this
+  }
+
+  /// Return the `ViewportId` of his parent.
+  ///
+  /// For the root viewport this will return [`ViewportId::ROOT`].
+  pub(crate) fn parent_viewport_id(&self) -> ViewportId {
+    let viewport_id = self.viewport_id();
+    *self.viewport_parents.get(&viewport_id).unwrap_or(&ViewportId::ROOT)
+  }
+
+  fn all_viewport_ids(&self) -> ViewportIdSet {
+    self.viewports.keys().copied().chain([ViewportId::ROOT]).collect()
+  }
+
+  /// The current active viewport
+  pub(crate) fn viewport(&mut self) -> &mut ViewportState {
+    self.viewports.entry(self.viewport_id()).or_default()
+  }
+
+  fn viewport_for(&mut self, viewport_id: ViewportId) -> &mut ViewportState {
+    self.viewports.entry(viewport_id).or_default()
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -684,2789 +634,2583 @@ impl ContextImpl {
 pub struct Context(Arc<RwLock<ContextImpl>>);
 
 impl std::fmt::Debug for Context {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Context").finish_non_exhaustive()
-    }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("Context").finish_non_exhaustive()
+  }
 }
 
 impl std::cmp::PartialEq for Context {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
+  fn eq(&self, other: &Self) -> bool {
+    Arc::ptr_eq(&self.0, &other.0)
+  }
 }
 
 impl Default for Context {
-    fn default() -> Self {
-        let ctx_impl = ContextImpl {
-            embed_viewports: true,
-            ..Default::default()
-        };
-        let ctx = Self(Arc::new(RwLock::new(ctx_impl)));
+  fn default() -> Self {
+    let ctx_impl = ContextImpl { embed_viewports: true, ..Default::default() };
+    let ctx = Self(Arc::new(RwLock::new(ctx_impl)));
 
-        // Register built-in plugins:
-        crate::debug_text::register(&ctx);
-        crate::text_selection::LabelSelectionState::register(&ctx);
-        crate::DragAndDrop::register(&ctx);
+    // Register built-in plugins:
+    crate::debug_text::register(&ctx);
+    crate::text_selection::LabelSelectionState::register(&ctx);
+    crate::DragAndDrop::register(&ctx);
 
-        ctx
-    }
+    ctx
+  }
 }
 
 impl Context {
-    /// Do read-only (shared access) transaction on Context
-    fn read<R>(&self, reader: impl FnOnce(&ContextImpl) -> R) -> R {
-        reader(&self.0.read())
-    }
+  /// Do read-only (shared access) transaction on Context
+  fn read<R>(&self, reader: impl FnOnce(&ContextImpl) -> R) -> R {
+    reader(&self.0.read())
+  }
 
-    /// Do read-write (exclusive access) transaction on Context
-    fn write<R>(&self, writer: impl FnOnce(&mut ContextImpl) -> R) -> R {
-        writer(&mut self.0.write())
-    }
+  /// Do read-write (exclusive access) transaction on Context
+  fn write<R>(&self, writer: impl FnOnce(&mut ContextImpl) -> R) -> R {
+    writer(&mut self.0.write())
+  }
 
-    /// Run the ui code for one frame.
-    ///
-    /// Put your widgets into a [`SidePanel`], [`TopBottomPanel`], [`CentralPanel`], [`Window`] or [`Area`].
-    ///
-    /// This will modify the internal reference to point to a new generation of [`Context`].
-    /// Any old clones of this [`Context`] will refer to the old [`Context`], which will not get new input.
-    ///
-    /// You can alternatively run [`Self::begin_frame`] and [`Context::end_frame`].
-    ///
-    /// ```
-    /// // One egui context that you keep reusing:
-    /// let mut ctx = egui::Context::default();
-    ///
-    /// // Each frame:
-    /// let input = egui::RawInput::default();
-    /// let full_output = ctx.run(input, |ctx| {
-    ///     egui::CentralPanel::default().show(&ctx, |ui| {
-    ///         ui.label("Hello egui!");
-    ///     });
-    /// });
-    /// // handle full_output
-    /// ```
-    #[must_use]
-    pub fn run(&self, new_input: RawInput, run_ui: impl FnOnce(&Self)) -> FullOutput {
-        crate::profile_function!();
+  /// Run the ui code for one frame.
+  ///
+  /// Put your widgets into a [`SidePanel`], [`TopBottomPanel`], [`CentralPanel`], [`Window`] or [`Area`].
+  ///
+  /// This will modify the internal reference to point to a new generation of [`Context`].
+  /// Any old clones of this [`Context`] will refer to the old [`Context`], which will not get new input.
+  ///
+  /// You can alternatively run [`Self::begin_frame`] and [`Context::end_frame`].
+  ///
+  /// ```
+  /// // One egui context that you keep reusing:
+  /// let mut ctx = egui::Context::default();
+  ///
+  /// // Each frame:
+  /// let input = egui::RawInput::default();
+  /// let full_output = ctx.run(input, |ctx| {
+  ///     egui::CentralPanel::default().show(&ctx, |ui| {
+  ///         ui.label("Hello egui!");
+  ///     });
+  /// });
+  /// // handle full_output
+  /// ```
+  #[must_use]
+  pub fn run(&self, new_input: RawInput, run_ui: impl FnOnce(&Self)) -> FullOutput {
+    crate::profile_function!();
 
-        self.begin_frame(new_input);
-        run_ui(self);
-        self.end_frame()
-    }
+    self.begin_frame(new_input);
+    run_ui(self);
+    self.end_frame()
+  }
 
-    /// An alternative to calling [`Self::run`].
-    ///
-    /// ```
-    /// // One egui context that you keep reusing:
-    /// let mut ctx = egui::Context::default();
-    ///
-    /// // Each frame:
-    /// let input = egui::RawInput::default();
-    /// ctx.begin_frame(input);
-    ///
-    /// egui::CentralPanel::default().show(&ctx, |ui| {
-    ///     ui.label("Hello egui!");
-    /// });
-    ///
-    /// let full_output = ctx.end_frame();
-    /// // handle full_output
-    /// ```
-    pub fn begin_frame(&self, new_input: RawInput) {
-        crate::profile_function!();
+  /// An alternative to calling [`Self::run`].
+  ///
+  /// ```
+  /// // One egui context that you keep reusing:
+  /// let mut ctx = egui::Context::default();
+  ///
+  /// // Each frame:
+  /// let input = egui::RawInput::default();
+  /// ctx.begin_frame(input);
+  ///
+  /// egui::CentralPanel::default().show(&ctx, |ui| {
+  ///     ui.label("Hello egui!");
+  /// });
+  ///
+  /// let full_output = ctx.end_frame();
+  /// // handle full_output
+  /// ```
+  pub fn begin_frame(&self, new_input: RawInput) {
+    crate::profile_function!();
 
-        self.write(|ctx| ctx.begin_frame_mut(new_input));
+    self.write(|ctx| ctx.begin_frame_mut(new_input));
 
-        // Plugins run just after the frame has started:
-        self.read(|ctx| ctx.plugins.clone()).on_begin_frame(self);
-    }
+    // Plugins run just after the frame has started:
+    self.read(|ctx| ctx.plugins.clone()).on_begin_frame(self);
+  }
 }
 
 /// ## Borrows parts of [`Context`]
 /// These functions all lock the [`Context`].
 /// Please see the documentation of [`Context`] for how locking works!
 impl Context {
-    /// Read-only access to [`InputState`].
-    ///
-    /// Note that this locks the [`Context`].
-    ///
-    /// ```
-    /// # let mut ctx = egui::Context::default();
-    /// ctx.input(|i| {
-    ///     // ⚠️ Using `ctx` (even from other `Arc` reference) again here will lead to a deadlock!
-    /// });
-    ///
-    /// if let Some(pos) = ctx.input(|i| i.pointer.hover_pos()) {
-    ///     // This is fine!
-    /// }
-    /// ```
-    #[inline]
-    pub fn input<R>(&self, reader: impl FnOnce(&InputState) -> R) -> R {
-        self.write(move |ctx| reader(&ctx.viewport().input))
+  /// Read-only access to [`InputState`].
+  ///
+  /// Note that this locks the [`Context`].
+  ///
+  /// ```
+  /// # let mut ctx = egui::Context::default();
+  /// ctx.input(|i| {
+  ///     // ⚠️ Using `ctx` (even from other `Arc` reference) again here will lead to a deadlock!
+  /// });
+  ///
+  /// if let Some(pos) = ctx.input(|i| i.pointer.hover_pos()) {
+  ///     // This is fine!
+  /// }
+  /// ```
+  #[inline]
+  pub fn input<R>(&self, reader: impl FnOnce(&InputState) -> R) -> R {
+    self.write(move |ctx| reader(&ctx.viewport().input))
+  }
+
+  /// This will create a `InputState::default()` if there is no input state for that viewport
+  #[inline]
+  pub fn input_for<R>(&self, id: ViewportId, reader: impl FnOnce(&InputState) -> R) -> R {
+    self.write(move |ctx| reader(&ctx.viewport_for(id).input))
+  }
+
+  /// Read-write access to [`InputState`].
+  #[inline]
+  pub fn input_mut<R>(&self, writer: impl FnOnce(&mut InputState) -> R) -> R {
+    self.input_mut_for(self.viewport_id(), writer)
+  }
+
+  /// This will create a `InputState::default()` if there is no input state for that viewport
+  #[inline]
+  pub fn input_mut_for<R>(&self, id: ViewportId, writer: impl FnOnce(&mut InputState) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.viewport_for(id).input))
+  }
+
+  /// Read-only access to [`Memory`].
+  #[inline]
+  pub fn memory<R>(&self, reader: impl FnOnce(&Memory) -> R) -> R {
+    self.read(move |ctx| reader(&ctx.memory))
+  }
+
+  /// Read-write access to [`Memory`].
+  #[inline]
+  pub fn memory_mut<R>(&self, writer: impl FnOnce(&mut Memory) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.memory))
+  }
+
+  /// Read-only access to [`IdTypeMap`], which stores superficial widget state.
+  #[inline]
+  pub fn data<R>(&self, reader: impl FnOnce(&IdTypeMap) -> R) -> R {
+    self.read(move |ctx| reader(&ctx.memory.data))
+  }
+
+  /// Read-write access to [`IdTypeMap`], which stores superficial widget state.
+  #[inline]
+  pub fn data_mut<R>(&self, writer: impl FnOnce(&mut IdTypeMap) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.memory.data))
+  }
+
+  /// Read-write access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
+  #[inline]
+  pub fn graphics_mut<R>(&self, writer: impl FnOnce(&mut GraphicLayers) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.viewport().graphics))
+  }
+
+  /// Read-only access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
+  #[inline]
+  pub fn graphics<R>(&self, reader: impl FnOnce(&GraphicLayers) -> R) -> R {
+    self.write(move |ctx| reader(&ctx.viewport().graphics))
+  }
+
+  /// Read-only access to [`PlatformOutput`].
+  ///
+  /// This is what egui outputs each frame.
+  ///
+  /// ```
+  /// # let mut ctx = egui::Context::default();
+  /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::Progress);
+  /// ```
+  #[inline]
+  pub fn output<R>(&self, reader: impl FnOnce(&PlatformOutput) -> R) -> R {
+    self.write(move |ctx| reader(&ctx.viewport().output))
+  }
+
+  /// Read-write access to [`PlatformOutput`].
+  #[inline]
+  pub fn output_mut<R>(&self, writer: impl FnOnce(&mut PlatformOutput) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.viewport().output))
+  }
+
+  /// Read-only access to [`FrameState`].
+  ///
+  /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
+  #[inline]
+  pub(crate) fn frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
+    self.write(move |ctx| reader(&ctx.viewport().this_frame))
+  }
+
+  /// Read-write access to [`FrameState`].
+  ///
+  /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
+  #[inline]
+  pub(crate) fn frame_state_mut<R>(&self, writer: impl FnOnce(&mut FrameState) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.viewport().this_frame))
+  }
+
+  /// Read-only access to the [`FrameState`] from the previous frame.
+  ///
+  /// This is swapped at the end of each frame.
+  #[inline]
+  pub(crate) fn prev_frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
+    self.write(move |ctx| reader(&ctx.viewport().prev_frame))
+  }
+
+  /// Read-only access to [`Fonts`].
+  ///
+  /// Not valid until first call to [`Context::run()`].
+  /// That's because since we don't know the proper `pixels_per_point` until then.
+  #[inline]
+  pub fn fonts<R>(&self, reader: impl FnOnce(&Fonts) -> R) -> R {
+    self.write(move |ctx| {
+      let pixels_per_point = ctx.pixels_per_point();
+      reader(ctx.fonts.get(&pixels_per_point.into()).expect("No fonts available until first call to Context::run()"))
+    })
+  }
+
+  /// Read-only access to [`Options`].
+  #[inline]
+  pub fn options<R>(&self, reader: impl FnOnce(&Options) -> R) -> R {
+    self.read(move |ctx| reader(&ctx.memory.options))
+  }
+
+  /// Read-write access to [`Options`].
+  #[inline]
+  pub fn options_mut<R>(&self, writer: impl FnOnce(&mut Options) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.memory.options))
+  }
+
+  /// Read-only access to [`TessellationOptions`].
+  #[inline]
+  pub fn tessellation_options<R>(&self, reader: impl FnOnce(&TessellationOptions) -> R) -> R {
+    self.read(move |ctx| reader(&ctx.memory.options.tessellation_options))
+  }
+
+  /// Read-write access to [`TessellationOptions`].
+  #[inline]
+  pub fn tessellation_options_mut<R>(&self, writer: impl FnOnce(&mut TessellationOptions) -> R) -> R {
+    self.write(move |ctx| writer(&mut ctx.memory.options.tessellation_options))
+  }
+
+  /// If the given [`Id`] has been used previously the same frame at different position,
+  /// then an error will be printed on screen.
+  ///
+  /// This function is already called for all widgets that do any interaction,
+  /// but you can call this from widgets that store state but that does not interact.
+  ///
+  /// The given [`Rect`] should be approximately where the widget will be.
+  /// The most important thing is that [`Rect::min`] is approximately correct,
+  /// because that's where the warning will be painted. If you don't know what size to pick, just pick [`Vec2::ZERO`].
+  pub fn check_for_id_clash(&self, id: Id, new_rect: Rect, what: &str) {
+    let prev_rect = self.frame_state_mut(move |state| state.used_ids.insert(id, new_rect));
+
+    if !self.options(|opt| opt.warn_on_id_clash) {
+      return;
     }
 
-    /// This will create a `InputState::default()` if there is no input state for that viewport
-    #[inline]
-    pub fn input_for<R>(&self, id: ViewportId, reader: impl FnOnce(&InputState) -> R) -> R {
-        self.write(move |ctx| reader(&ctx.viewport_for(id).input))
+    let Some(prev_rect) = prev_rect else { return };
+
+    // it is ok to reuse the same ID for e.g. a frame around a widget,
+    // or to check for interaction with the same widget twice:
+    let is_same_rect = prev_rect.expand(0.1).contains_rect(new_rect) || new_rect.expand(0.1).contains_rect(prev_rect);
+    if is_same_rect {
+      return;
     }
 
-    /// Read-write access to [`InputState`].
-    #[inline]
-    pub fn input_mut<R>(&self, writer: impl FnOnce(&mut InputState) -> R) -> R {
-        self.input_mut_for(self.viewport_id(), writer)
-    }
+    let show_error = |widget_rect: Rect, text: String| {
+      let screen_rect = self.screen_rect();
 
-    /// This will create a `InputState::default()` if there is no input state for that viewport
-    #[inline]
-    pub fn input_mut_for<R>(&self, id: ViewportId, writer: impl FnOnce(&mut InputState) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.viewport_for(id).input))
-    }
+      let text = format!("🔥 {text}");
+      let color = self.style().visuals.error_fg_color;
+      let painter = self.debug_painter();
+      painter.rect_stroke(widget_rect, 0.0, (1.0, color));
 
-    /// Read-only access to [`Memory`].
-    #[inline]
-    pub fn memory<R>(&self, reader: impl FnOnce(&Memory) -> R) -> R {
-        self.read(move |ctx| reader(&ctx.memory))
-    }
+      let below = widget_rect.bottom() + 32.0 < screen_rect.bottom();
 
-    /// Read-write access to [`Memory`].
-    #[inline]
-    pub fn memory_mut<R>(&self, writer: impl FnOnce(&mut Memory) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.memory))
-    }
+      let text_rect = if below {
+        painter.debug_text(widget_rect.left_bottom() + vec2(0.0, 2.0), Align2::LEFT_TOP, color, text)
+      } else {
+        painter.debug_text(widget_rect.left_top() - vec2(0.0, 2.0), Align2::LEFT_BOTTOM, color, text)
+      };
 
-    /// Read-only access to [`IdTypeMap`], which stores superficial widget state.
-    #[inline]
-    pub fn data<R>(&self, reader: impl FnOnce(&IdTypeMap) -> R) -> R {
-        self.read(move |ctx| reader(&ctx.memory.data))
-    }
+      if let Some(pointer_pos) = self.pointer_hover_pos() {
+        if text_rect.contains(pointer_pos) {
+          let tooltip_pos =
+            if below { text_rect.left_bottom() + vec2(2.0, 4.0) } else { text_rect.left_top() + vec2(2.0, -4.0) };
 
-    /// Read-write access to [`IdTypeMap`], which stores superficial widget state.
-    #[inline]
-    pub fn data_mut<R>(&self, writer: impl FnOnce(&mut IdTypeMap) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.memory.data))
-    }
-
-    /// Read-write access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
-    #[inline]
-    pub fn graphics_mut<R>(&self, writer: impl FnOnce(&mut GraphicLayers) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.viewport().graphics))
-    }
-
-    /// Read-only access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
-    #[inline]
-    pub fn graphics<R>(&self, reader: impl FnOnce(&GraphicLayers) -> R) -> R {
-        self.write(move |ctx| reader(&ctx.viewport().graphics))
-    }
-
-    /// Read-only access to [`PlatformOutput`].
-    ///
-    /// This is what egui outputs each frame.
-    ///
-    /// ```
-    /// # let mut ctx = egui::Context::default();
-    /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::Progress);
-    /// ```
-    #[inline]
-    pub fn output<R>(&self, reader: impl FnOnce(&PlatformOutput) -> R) -> R {
-        self.write(move |ctx| reader(&ctx.viewport().output))
-    }
-
-    /// Read-write access to [`PlatformOutput`].
-    #[inline]
-    pub fn output_mut<R>(&self, writer: impl FnOnce(&mut PlatformOutput) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.viewport().output))
-    }
-
-    /// Read-only access to [`FrameState`].
-    ///
-    /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
-    #[inline]
-    pub(crate) fn frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
-        self.write(move |ctx| reader(&ctx.viewport().this_frame))
-    }
-
-    /// Read-write access to [`FrameState`].
-    ///
-    /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
-    #[inline]
-    pub(crate) fn frame_state_mut<R>(&self, writer: impl FnOnce(&mut FrameState) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.viewport().this_frame))
-    }
-
-    /// Read-only access to the [`FrameState`] from the previous frame.
-    ///
-    /// This is swapped at the end of each frame.
-    #[inline]
-    pub(crate) fn prev_frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
-        self.write(move |ctx| reader(&ctx.viewport().prev_frame))
-    }
-
-    /// Read-only access to [`Fonts`].
-    ///
-    /// Not valid until first call to [`Context::run()`].
-    /// That's because since we don't know the proper `pixels_per_point` until then.
-    #[inline]
-    pub fn fonts<R>(&self, reader: impl FnOnce(&Fonts) -> R) -> R {
-        self.write(move |ctx| {
-            let pixels_per_point = ctx.pixels_per_point();
-            reader(
-                ctx.fonts
-                    .get(&pixels_per_point.into())
-                    .expect("No fonts available until first call to Context::run()"),
-            )
-        })
-    }
-
-    /// Read-only access to [`Options`].
-    #[inline]
-    pub fn options<R>(&self, reader: impl FnOnce(&Options) -> R) -> R {
-        self.read(move |ctx| reader(&ctx.memory.options))
-    }
-
-    /// Read-write access to [`Options`].
-    #[inline]
-    pub fn options_mut<R>(&self, writer: impl FnOnce(&mut Options) -> R) -> R {
-        self.write(move |ctx| writer(&mut ctx.memory.options))
-    }
-
-    /// Read-only access to [`TessellationOptions`].
-    #[inline]
-    pub fn tessellation_options<R>(&self, reader: impl FnOnce(&TessellationOptions) -> R) -> R {
-        self.read(move |ctx| reader(&ctx.memory.options.tessellation_options))
-    }
-
-    /// Read-write access to [`TessellationOptions`].
-    #[inline]
-    pub fn tessellation_options_mut<R>(
-        &self,
-        writer: impl FnOnce(&mut TessellationOptions) -> R,
-    ) -> R {
-        self.write(move |ctx| writer(&mut ctx.memory.options.tessellation_options))
-    }
-
-    /// If the given [`Id`] has been used previously the same frame at different position,
-    /// then an error will be printed on screen.
-    ///
-    /// This function is already called for all widgets that do any interaction,
-    /// but you can call this from widgets that store state but that does not interact.
-    ///
-    /// The given [`Rect`] should be approximately where the widget will be.
-    /// The most important thing is that [`Rect::min`] is approximately correct,
-    /// because that's where the warning will be painted. If you don't know what size to pick, just pick [`Vec2::ZERO`].
-    pub fn check_for_id_clash(&self, id: Id, new_rect: Rect, what: &str) {
-        let prev_rect = self.frame_state_mut(move |state| state.used_ids.insert(id, new_rect));
-
-        if !self.options(|opt| opt.warn_on_id_clash) {
-            return;
-        }
-
-        let Some(prev_rect) = prev_rect else { return };
-
-        // it is ok to reuse the same ID for e.g. a frame around a widget,
-        // or to check for interaction with the same widget twice:
-        let is_same_rect = prev_rect.expand(0.1).contains_rect(new_rect)
-            || new_rect.expand(0.1).contains_rect(prev_rect);
-        if is_same_rect {
-            return;
-        }
-
-        let show_error = |widget_rect: Rect, text: String| {
-            let screen_rect = self.screen_rect();
-
-            let text = format!("🔥 {text}");
-            let color = self.style().visuals.error_fg_color;
-            let painter = self.debug_painter();
-            painter.rect_stroke(widget_rect, 0.0, (1.0, color));
-
-            let below = widget_rect.bottom() + 32.0 < screen_rect.bottom();
-
-            let text_rect = if below {
-                painter.debug_text(
-                    widget_rect.left_bottom() + vec2(0.0, 2.0),
-                    Align2::LEFT_TOP,
-                    color,
-                    text,
-                )
-            } else {
-                painter.debug_text(
-                    widget_rect.left_top() - vec2(0.0, 2.0),
-                    Align2::LEFT_BOTTOM,
-                    color,
-                    text,
-                )
-            };
-
-            if let Some(pointer_pos) = self.pointer_hover_pos() {
-                if text_rect.contains(pointer_pos) {
-                    let tooltip_pos = if below {
-                        text_rect.left_bottom() + vec2(2.0, 4.0)
-                    } else {
-                        text_rect.left_top() + vec2(2.0, -4.0)
-                    };
-
-                    painter.error(
-                        tooltip_pos,
-                        format!("Widget is {} this text.\n\n\
+          painter.error(
+            tooltip_pos,
+            format!(
+              "Widget is {} this text.\n\n\
                              ID clashes happens when things like Windows or CollapsingHeaders share names,\n\
                              or when things like Plot and Grid:s aren't given unique id_source:s.\n\n\
                              Sometimes the solution is to use ui.push_id.",
-                         if below { "above" } else { "below" })
-                    );
-                }
-            }
-        };
-
-        let id_str = id.short_debug_format();
-
-        if prev_rect.min.distance(new_rect.min) < 4.0 {
-            show_error(new_rect, format!("Double use of {what} ID {id_str}"));
-        } else {
-            show_error(prev_rect, format!("First use of {what} ID {id_str}"));
-            show_error(new_rect, format!("Second use of {what} ID {id_str}"));
+              if below { "above" } else { "below" }
+            ),
+          );
         }
+      }
+    };
+
+    let id_str = id.short_debug_format();
+
+    if prev_rect.min.distance(new_rect.min) < 4.0 {
+      show_error(new_rect, format!("Double use of {what} ID {id_str}"));
+    } else {
+      show_error(prev_rect, format!("First use of {what} ID {id_str}"));
+      show_error(new_rect, format!("Second use of {what} ID {id_str}"));
+    }
+  }
+
+  // ---------------------------------------------------------------------
+
+  /// Create a widget and check for interaction.
+  ///
+  /// If this is not called, the widget doesn't exist.
+  ///
+  /// You should use [`Ui::interact`] instead.
+  ///
+  /// If the widget already exists, its state (sense, Rect, etc) will be updated.
+  #[allow(clippy::too_many_arguments)]
+  pub(crate) fn create_widget(&self, w: WidgetRect) -> Response {
+    // Remember this widget
+    self.write(|ctx| {
+      let viewport = ctx.viewport();
+
+      // We add all widgets here, even non-interactive ones,
+      // because we need this list not only for checking for blocking widgets,
+      // but also to know when we have reached the widget we are checking for cover.
+      viewport.this_frame.widgets.insert(w.layer_id, w);
+
+      if w.sense.focusable {
+        ctx.memory.interested_in_focus(w.id);
+      }
+    });
+
+    if !w.enabled || !w.sense.focusable || !w.layer_id.allow_interaction() {
+      // Not interested or allowed input:
+      self.memory_mut(|mem| mem.surrender_focus(w.id));
     }
 
-    // ---------------------------------------------------------------------
+    if w.sense.interactive() || w.sense.focusable {
+      self.check_for_id_clash(w.id, w.rect, "widget");
+    }
 
-    /// Create a widget and check for interaction.
-    ///
-    /// If this is not called, the widget doesn't exist.
-    ///
-    /// You should use [`Ui::interact`] instead.
-    ///
-    /// If the widget already exists, its state (sense, Rect, etc) will be updated.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn create_widget(&self, w: WidgetRect) -> Response {
-        // Remember this widget
-        self.write(|ctx| {
-            let viewport = ctx.viewport();
+    #[allow(clippy::let_and_return)]
+    let res = self.get_response(w);
 
-            // We add all widgets here, even non-interactive ones,
-            // because we need this list not only for checking for blocking widgets,
-            // but also to know when we have reached the widget we are checking for cover.
-            viewport.this_frame.widgets.insert(w.layer_id, w);
+    #[cfg(feature = "accesskit")]
+    if w.sense.focusable {
+      // Make sure anything that can receive focus has an AccessKit node.
+      // TODO(mwcampbell): For nodes that are filled from widget info,
+      // some information is written to the node twice.
+      self.accesskit_node_builder(w.id, |builder| res.fill_accesskit_node_common(builder));
+    }
 
-            if w.sense.focusable {
-                ctx.memory.interested_in_focus(w.id);
+    res
+  }
+
+  /// Read the response of some widget, which may be called _before_ creating the widget (!).
+  ///
+  /// This is because widget interaction happens at the start of the frame, using the previous frame's widgets.
+  ///
+  /// If the widget was not visible the previous frame (or this frame), this will return `None`.
+  pub fn read_response(&self, id: Id) -> Option<Response> {
+    self
+      .write(|ctx| {
+        let viewport = ctx.viewport();
+        viewport.this_frame.widgets.get(id).or_else(|| viewport.prev_frame.widgets.get(id)).copied()
+      })
+      .map(|widget_rect| self.get_response(widget_rect))
+  }
+
+  /// Returns `true` if the widget with the given `Id` contains the pointer.
+  #[deprecated = "Use Response.contains_pointer or Context::read_response instead"]
+  pub fn widget_contains_pointer(&self, id: Id) -> bool {
+    self.read_response(id).map_or(false, |response| response.contains_pointer)
+  }
+
+  /// Do all interaction for an existing widget, without (re-)registering it.
+  fn get_response(&self, widget_rect: WidgetRect) -> Response {
+    let WidgetRect { id, layer_id, rect, interact_rect, sense, enabled } = widget_rect;
+
+    // previous frame + "highlight next frame" == "highlight this frame"
+    let highlighted = self.prev_frame_state(|fs| fs.highlight_next_frame.contains(&id));
+
+    let mut res = Response {
+      ctx: self.clone(),
+      layer_id,
+      id,
+      rect,
+      interact_rect,
+      sense,
+      enabled,
+      contains_pointer: false,
+      hovered: false,
+      highlighted,
+      clicked: false,
+      fake_primary_click: false,
+      long_touched: false,
+      drag_started: false,
+      dragged: false,
+      drag_stopped: false,
+      is_pointer_button_down_on: false,
+      interact_pointer_pos: None,
+      changed: false,
+    };
+
+    self.write(|ctx| {
+      let viewport = ctx.viewports.entry(ctx.viewport_id()).or_default();
+
+      res.contains_pointer = viewport.interact_widgets.contains_pointer.contains(&id);
+
+      let input = &viewport.input;
+      let memory = &mut ctx.memory;
+
+      if enabled
+        && sense.click
+        && memory.has_focus(id)
+        && (input.key_pressed(Key::Space) || input.key_pressed(Key::Enter))
+      {
+        // Space/enter works like a primary click for e.g. selected buttons
+        res.fake_primary_click = true;
+      }
+
+      #[cfg(feature = "accesskit")]
+      if enabled && sense.click && input.has_accesskit_action_request(id, accesskit::Action::Default) {
+        res.fake_primary_click = true;
+      }
+
+      if enabled && sense.click && Some(id) == viewport.interact_widgets.long_touched {
+        res.long_touched = true;
+      }
+
+      let interaction = memory.interaction();
+
+      res.is_pointer_button_down_on =
+        interaction.potential_click_id == Some(id) || interaction.potential_drag_id == Some(id);
+
+      if res.enabled {
+        res.hovered = viewport.interact_widgets.hovered.contains(&id);
+        res.dragged = Some(id) == viewport.interact_widgets.dragged;
+        res.drag_started = Some(id) == viewport.interact_widgets.drag_started;
+        res.drag_stopped = Some(id) == viewport.interact_widgets.drag_stopped;
+      }
+
+      let clicked = Some(id) == viewport.interact_widgets.clicked;
+      let mut any_press = false;
+
+      for pointer_event in &input.pointer.pointer_events {
+        match pointer_event {
+          PointerEvent::Moved(_) => {}
+          PointerEvent::Pressed { .. } => {
+            any_press = true;
+          }
+          PointerEvent::Released { click, .. } => {
+            if enabled && sense.click && clicked && click.is_some() {
+              res.clicked = true;
             }
-        });
 
-        if !w.enabled || !w.sense.focusable || !w.layer_id.allow_interaction() {
-            // Not interested or allowed input:
-            self.memory_mut(|mem| mem.surrender_focus(w.id));
+            res.is_pointer_button_down_on = false;
+            res.dragged = false;
+          }
         }
+      }
 
-        if w.sense.interactive() || w.sense.focusable {
-            self.check_for_id_clash(w.id, w.rect, "widget");
-        }
-
-        #[allow(clippy::let_and_return)]
-        let res = self.get_response(w);
-
-        #[cfg(feature = "accesskit")]
-        if w.sense.focusable {
-            // Make sure anything that can receive focus has an AccessKit node.
-            // TODO(mwcampbell): For nodes that are filled from widget info,
-            // some information is written to the node twice.
-            self.accesskit_node_builder(w.id, |builder| res.fill_accesskit_node_common(builder));
-        }
-
-        res
-    }
-
-    /// Read the response of some widget, which may be called _before_ creating the widget (!).
-    ///
-    /// This is because widget interaction happens at the start of the frame, using the previous frame's widgets.
-    ///
-    /// If the widget was not visible the previous frame (or this frame), this will return `None`.
-    pub fn read_response(&self, id: Id) -> Option<Response> {
-        self.write(|ctx| {
-            let viewport = ctx.viewport();
-            viewport
-                .this_frame
-                .widgets
-                .get(id)
-                .or_else(|| viewport.prev_frame.widgets.get(id))
-                .copied()
-        })
-        .map(|widget_rect| self.get_response(widget_rect))
-    }
-
-    /// Returns `true` if the widget with the given `Id` contains the pointer.
-    #[deprecated = "Use Response.contains_pointer or Context::read_response instead"]
-    pub fn widget_contains_pointer(&self, id: Id) -> bool {
-        self.read_response(id)
-            .map_or(false, |response| response.contains_pointer)
-    }
-
-    /// Do all interaction for an existing widget, without (re-)registering it.
-    fn get_response(&self, widget_rect: WidgetRect) -> Response {
-        let WidgetRect {
-            id,
-            layer_id,
-            rect,
-            interact_rect,
-            sense,
-            enabled,
-        } = widget_rect;
-
-        // previous frame + "highlight next frame" == "highlight this frame"
-        let highlighted = self.prev_frame_state(|fs| fs.highlight_next_frame.contains(&id));
-
-        let mut res = Response {
-            ctx: self.clone(),
-            layer_id,
-            id,
-            rect,
-            interact_rect,
-            sense,
-            enabled,
-            contains_pointer: false,
-            hovered: false,
-            highlighted,
-            clicked: false,
-            fake_primary_click: false,
-            long_touched: false,
-            drag_started: false,
-            dragged: false,
-            drag_stopped: false,
-            is_pointer_button_down_on: false,
-            interact_pointer_pos: None,
-            changed: false,
-        };
-
-        self.write(|ctx| {
-            let viewport = ctx.viewports.entry(ctx.viewport_id()).or_default();
-
-            res.contains_pointer = viewport.interact_widgets.contains_pointer.contains(&id);
-
-            let input = &viewport.input;
-            let memory = &mut ctx.memory;
-
-            if enabled
-                && sense.click
-                && memory.has_focus(id)
-                && (input.key_pressed(Key::Space) || input.key_pressed(Key::Enter))
-            {
-                // Space/enter works like a primary click for e.g. selected buttons
-                res.fake_primary_click = true;
-            }
-
-            #[cfg(feature = "accesskit")]
-            if enabled
-                && sense.click
-                && input.has_accesskit_action_request(id, accesskit::Action::Default)
-            {
-                res.fake_primary_click = true;
-            }
-
-            if enabled && sense.click && Some(id) == viewport.interact_widgets.long_touched {
-                res.long_touched = true;
-            }
-
-            let interaction = memory.interaction();
-
-            res.is_pointer_button_down_on = interaction.potential_click_id == Some(id)
-                || interaction.potential_drag_id == Some(id);
-
-            if res.enabled {
-                res.hovered = viewport.interact_widgets.hovered.contains(&id);
-                res.dragged = Some(id) == viewport.interact_widgets.dragged;
-                res.drag_started = Some(id) == viewport.interact_widgets.drag_started;
-                res.drag_stopped = Some(id) == viewport.interact_widgets.drag_stopped;
-            }
-
-            let clicked = Some(id) == viewport.interact_widgets.clicked;
-            let mut any_press = false;
-
-            for pointer_event in &input.pointer.pointer_events {
-                match pointer_event {
-                    PointerEvent::Moved(_) => {}
-                    PointerEvent::Pressed { .. } => {
-                        any_press = true;
-                    }
-                    PointerEvent::Released { click, .. } => {
-                        if enabled && sense.click && clicked && click.is_some() {
-                            res.clicked = true;
-                        }
-
-                        res.is_pointer_button_down_on = false;
-                        res.dragged = false;
-                    }
-                }
-            }
-
-            // is_pointer_button_down_on is false when released, but we want interact_pointer_pos
-            // to still work.
-            let is_interacted_with =
-                res.is_pointer_button_down_on || res.long_touched || clicked || res.drag_stopped;
-            if is_interacted_with {
-                res.interact_pointer_pos = input.pointer.interact_pos();
-                if let (Some(transform), Some(pos)) = (
-                    memory.layer_transforms.get(&res.layer_id),
-                    &mut res.interact_pointer_pos,
-                ) {
-                    *pos = transform.inverse() * *pos;
-                }
-            }
-
-            if input.pointer.any_down() && !is_interacted_with {
-                // We don't hover widgets while interacting with *other* widgets:
-                res.hovered = false;
-            }
-
-            let pointer_pressed_elsewhere = any_press && !res.hovered;
-            if pointer_pressed_elsewhere && memory.has_focus(id) {
-                memory.surrender_focus(id);
-            }
-        });
-
-        res
-    }
-
-    /// This is called by [`Response::widget_info`], but can also be called directly.
-    ///
-    /// With some debug flags it will store the widget info in [`WidgetRects`] for later display.
-    #[inline]
-    pub fn register_widget_info(&self, id: Id, make_info: impl Fn() -> crate::WidgetInfo) {
-        #[cfg(debug_assertions)]
-        self.write(|ctx| {
-            if ctx.memory.options.style.debug.show_interactive_widgets {
-                ctx.viewport().this_frame.widgets.set_info(id, make_info());
-            }
-        });
-
-        #[cfg(not(debug_assertions))]
+      // is_pointer_button_down_on is false when released, but we want interact_pointer_pos
+      // to still work.
+      let is_interacted_with = res.is_pointer_button_down_on || res.long_touched || clicked || res.drag_stopped;
+      if is_interacted_with {
+        res.interact_pointer_pos = input.pointer.interact_pos();
+        if let (Some(transform), Some(pos)) =
+          (memory.layer_transforms.get(&res.layer_id), &mut res.interact_pointer_pos)
         {
-            _ = (self, id, make_info);
+          *pos = transform.inverse() * *pos;
         }
+      }
+
+      if input.pointer.any_down() && !is_interacted_with {
+        // We don't hover widgets while interacting with *other* widgets:
+        res.hovered = false;
+      }
+
+      let pointer_pressed_elsewhere = any_press && !res.hovered;
+      if pointer_pressed_elsewhere && memory.has_focus(id) {
+        memory.surrender_focus(id);
+      }
+    });
+
+    res
+  }
+
+  /// This is called by [`Response::widget_info`], but can also be called directly.
+  ///
+  /// With some debug flags it will store the widget info in [`WidgetRects`] for later display.
+  #[inline]
+  pub fn register_widget_info(&self, id: Id, make_info: impl Fn() -> crate::WidgetInfo) {
+    #[cfg(debug_assertions)]
+    self.write(|ctx| {
+      if ctx.memory.options.style.debug.show_interactive_widgets {
+        ctx.viewport().this_frame.widgets.set_info(id, make_info());
+      }
+    });
+
+    #[cfg(not(debug_assertions))]
+    {
+      _ = (self, id, make_info);
     }
+  }
 
-    /// Get a full-screen painter for a new or existing layer
-    pub fn layer_painter(&self, layer_id: LayerId) -> Painter {
-        let screen_rect = self.screen_rect();
-        Painter::new(self.clone(), layer_id, screen_rect)
+  /// Get a full-screen painter for a new or existing layer
+  pub fn layer_painter(&self, layer_id: LayerId) -> Painter {
+    let screen_rect = self.screen_rect();
+    Painter::new(self.clone(), layer_id, screen_rect)
+  }
+
+  /// Paint on top of everything else
+  pub fn debug_painter(&self) -> Painter {
+    Self::layer_painter(self, LayerId::debug())
+  }
+
+  /// Print this text next to the cursor at the end of the frame.
+  ///
+  /// If you call this multiple times, the text will be appended.
+  ///
+  /// This only works if compiled with `debug_assertions`.
+  ///
+  /// ```
+  /// # let ctx = egui::Context::default();
+  /// # let state = true;
+  /// ctx.debug_text(format!("State: {state:?}"));
+  /// ```
+  ///
+  /// This is just a convenience for calling [`crate::debug_text::print`].
+  #[track_caller]
+  pub fn debug_text(&self, text: impl Into<WidgetText>) {
+    crate::debug_text::print(self, text);
+  }
+
+  /// What operating system are we running on?
+  ///
+  /// When compiling natively, this is
+  /// figured out from the `target_os`.
+  ///
+  /// For web, this can be figured out from the user-agent,
+  /// and is done so by [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe).
+  pub fn os(&self) -> OperatingSystem {
+    self.read(|ctx| ctx.os)
+  }
+
+  /// Set the operating system we are running on.
+  ///
+  /// If you are writing wasm-based integration for egui you
+  /// may want to set this based on e.g. the user-agent.
+  pub fn set_os(&self, os: OperatingSystem) {
+    self.write(|ctx| ctx.os = os);
+  }
+
+  /// Set the cursor icon.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// # let ctx = egui::Context::default();
+  /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
+  /// ```
+  pub fn set_cursor_icon(&self, cursor_icon: CursorIcon) {
+    self.output_mut(|o| o.cursor_icon = cursor_icon);
+  }
+
+  /// Open an URL in a browser.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// # let ctx = egui::Context::default();
+  /// # let open_url = egui::OpenUrl::same_tab("http://www.example.com");
+  /// ctx.output_mut(|o| o.open_url = Some(open_url));
+  /// ```
+  pub fn open_url(&self, open_url: crate::OpenUrl) {
+    self.output_mut(|o| o.open_url = Some(open_url));
+  }
+
+  /// Copy the given text to the system clipboard.
+  ///
+  /// Empty strings are ignored.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// # let ctx = egui::Context::default();
+  /// ctx.output_mut(|o| o.copied_text = "Copy this".to_owned());
+  /// ```
+  pub fn copy_text(&self, text: String) {
+    self.output_mut(|o| o.copied_text = text);
+  }
+
+  /// Format the given shortcut in a human-readable way (e.g. `Ctrl+Shift+X`).
+  ///
+  /// Can be used to get the text for [`Button::shortcut_text`].
+  pub fn format_shortcut(&self, shortcut: &KeyboardShortcut) -> String {
+    let os = self.os();
+
+    let is_mac = matches!(os, OperatingSystem::Mac | OperatingSystem::IOS);
+
+    let can_show_symbols = || {
+      let ModifierNames { alt, ctrl, shift, mac_cmd, .. } = ModifierNames::SYMBOLS;
+
+      let font_id = TextStyle::Body.resolve(&self.style());
+      self.fonts(|f| {
+        let mut lock = f.lock();
+        let font = lock.fonts.font(&font_id);
+        font.has_glyphs(alt) && font.has_glyphs(ctrl) && font.has_glyphs(shift) && font.has_glyphs(mac_cmd)
+      })
+    };
+
+    if is_mac && can_show_symbols() {
+      shortcut.format(&ModifierNames::SYMBOLS, is_mac)
+    } else {
+      shortcut.format(&ModifierNames::NAMES, is_mac)
     }
+  }
 
-    /// Paint on top of everything else
-    pub fn debug_painter(&self) -> Painter {
-        Self::layer_painter(self, LayerId::debug())
+  /// The current frame number for the current viewport.
+  ///
+  /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
+  ///
+  /// Between calls to [`Self::run`], this is the frame number of the coming frame.
+  pub fn frame_nr(&self) -> u64 {
+    self.frame_nr_for(self.viewport_id())
+  }
+
+  /// The current frame number.
+  ///
+  /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
+  ///
+  /// Between calls to [`Self::run`], this is the frame number of the coming frame.
+  pub fn frame_nr_for(&self, id: ViewportId) -> u64 {
+    self.read(|ctx| ctx.viewports.get(&id).map_or(0, |v| v.repaint.frame_nr))
+  }
+
+  /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
+  ///
+  /// If this is called at least once in a frame, then there will be another frame right after this.
+  /// Call as many times as you wish, only one repaint will be issued.
+  ///
+  /// To request repaint with a delay, use [`Self::request_repaint_after`].
+  ///
+  /// If called from outside the UI thread, the UI thread will wake up and run,
+  /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
+  /// (this will work on `eframe`).
+  ///
+  /// This will repaint the current viewport.
+  #[track_caller]
+  pub fn request_repaint(&self) {
+    self.request_repaint_of(self.viewport_id());
+  }
+
+  /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
+  ///
+  /// If this is called at least once in a frame, then there will be another frame right after this.
+  /// Call as many times as you wish, only one repaint will be issued.
+  ///
+  /// To request repaint with a delay, use [`Self::request_repaint_after_for`].
+  ///
+  /// If called from outside the UI thread, the UI thread will wake up and run,
+  /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
+  /// (this will work on `eframe`).
+  ///
+  /// This will repaint the specified viewport.
+  #[track_caller]
+  pub fn request_repaint_of(&self, id: ViewportId) {
+    let cause = RepaintCause::new();
+    self.write(|ctx| ctx.request_repaint(id, cause));
+  }
+
+  /// Request repaint after at most the specified duration elapses.
+  ///
+  /// The backend can chose to repaint sooner, for instance if some other code called
+  /// this method with a lower duration, or if new events arrived.
+  ///
+  /// The function can be multiple times, but only the *smallest* duration will be considered.
+  /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
+  /// after `1 second`
+  ///
+  /// This is primarily useful for applications who would like to save battery by avoiding wasted
+  /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
+  /// and outdated if it is not updated for too long.
+  ///
+  /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
+  /// resources repainting multiple times within the same second (when you have no input),
+  /// just calculate the difference of duration between current time and next second change,
+  /// and call this function, to make sure that you are displaying the latest updated time, but
+  /// not wasting resources on needless repaints within the same second.
+  ///
+  /// ### Quirk:
+  /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
+  /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
+  /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
+  /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
+  /// So, it's not that we are requesting repaint within X duration. We are rather timing out
+  /// during app idle time where we are not receiving any new input events.
+  ///
+  /// This repaints the current viewport
+  #[track_caller]
+  pub fn request_repaint_after(&self, duration: Duration) {
+    self.request_repaint_after_for(duration, self.viewport_id());
+  }
+
+  /// Repaint after this many seconds.
+  ///
+  /// See [`Self::request_repaint_after`] for details.
+  #[track_caller]
+  pub fn request_repaint_after_secs(&self, seconds: f32) {
+    if let Ok(duration) = std::time::Duration::try_from_secs_f32(seconds) {
+      self.request_repaint_after(duration);
     }
+  }
 
-    /// Print this text next to the cursor at the end of the frame.
-    ///
-    /// If you call this multiple times, the text will be appended.
-    ///
-    /// This only works if compiled with `debug_assertions`.
-    ///
-    /// ```
-    /// # let ctx = egui::Context::default();
-    /// # let state = true;
-    /// ctx.debug_text(format!("State: {state:?}"));
-    /// ```
-    ///
-    /// This is just a convenience for calling [`crate::debug_text::print`].
-    #[track_caller]
-    pub fn debug_text(&self, text: impl Into<WidgetText>) {
-        crate::debug_text::print(self, text);
-    }
+  /// Request repaint after at most the specified duration elapses.
+  ///
+  /// The backend can chose to repaint sooner, for instance if some other code called
+  /// this method with a lower duration, or if new events arrived.
+  ///
+  /// The function can be multiple times, but only the *smallest* duration will be considered.
+  /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
+  /// after `1 second`
+  ///
+  /// This is primarily useful for applications who would like to save battery by avoiding wasted
+  /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
+  /// and outdated if it is not updated for too long.
+  ///
+  /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
+  /// resources repainting multiple times within the same second (when you have no input),
+  /// just calculate the difference of duration between current time and next second change,
+  /// and call this function, to make sure that you are displaying the latest updated time, but
+  /// not wasting resources on needless repaints within the same second.
+  ///
+  /// ### Quirk:
+  /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
+  /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
+  /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
+  /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
+  /// So, it's not that we are requesting repaint within X duration. We are rather timing out
+  /// during app idle time where we are not receiving any new input events.
+  ///
+  /// This repaints the specified viewport
+  #[track_caller]
+  pub fn request_repaint_after_for(&self, duration: Duration, id: ViewportId) {
+    let cause = RepaintCause::new();
+    self.write(|ctx| ctx.request_repaint_after(duration, id, cause));
+  }
 
-    /// What operating system are we running on?
-    ///
-    /// When compiling natively, this is
-    /// figured out from the `target_os`.
-    ///
-    /// For web, this can be figured out from the user-agent,
-    /// and is done so by [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe).
-    pub fn os(&self) -> OperatingSystem {
-        self.read(|ctx| ctx.os)
-    }
+  /// Was a repaint requested last frame for the current viewport?
+  #[must_use]
+  pub fn requested_repaint_last_frame(&self) -> bool {
+    self.requested_repaint_last_frame_for(&self.viewport_id())
+  }
 
-    /// Set the operating system we are running on.
-    ///
-    /// If you are writing wasm-based integration for egui you
-    /// may want to set this based on e.g. the user-agent.
-    pub fn set_os(&self, os: OperatingSystem) {
-        self.write(|ctx| ctx.os = os);
-    }
+  /// Was a repaint requested last frame for the given viewport?
+  #[must_use]
+  pub fn requested_repaint_last_frame_for(&self, viewport_id: &ViewportId) -> bool {
+    self.read(|ctx| ctx.requested_immediate_repaint_prev_frame(viewport_id))
+  }
 
-    /// Set the cursor icon.
-    ///
-    /// Equivalent to:
-    /// ```
-    /// # let ctx = egui::Context::default();
-    /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
-    /// ```
-    pub fn set_cursor_icon(&self, cursor_icon: CursorIcon) {
-        self.output_mut(|o| o.cursor_icon = cursor_icon);
-    }
+  /// Has a repaint been requested for the current viewport?
+  #[must_use]
+  pub fn has_requested_repaint(&self) -> bool {
+    self.has_requested_repaint_for(&self.viewport_id())
+  }
 
-    /// Open an URL in a browser.
-    ///
-    /// Equivalent to:
-    /// ```
-    /// # let ctx = egui::Context::default();
-    /// # let open_url = egui::OpenUrl::same_tab("http://www.example.com");
-    /// ctx.output_mut(|o| o.open_url = Some(open_url));
-    /// ```
-    pub fn open_url(&self, open_url: crate::OpenUrl) {
-        self.output_mut(|o| o.open_url = Some(open_url));
-    }
+  /// Has a repaint been requested for the given viewport?
+  #[must_use]
+  pub fn has_requested_repaint_for(&self, viewport_id: &ViewportId) -> bool {
+    self.read(|ctx| ctx.has_requested_repaint(viewport_id))
+  }
 
-    /// Copy the given text to the system clipboard.
-    ///
-    /// Empty strings are ignored.
-    ///
-    /// Equivalent to:
-    /// ```
-    /// # let ctx = egui::Context::default();
-    /// ctx.output_mut(|o| o.copied_text = "Copy this".to_owned());
-    /// ```
-    pub fn copy_text(&self, text: String) {
-        self.output_mut(|o| o.copied_text = text);
-    }
+  /// Why are we repainting?
+  ///
+  /// This can be helpful in debugging why egui is constantly repainting.
+  pub fn repaint_causes(&self) -> Vec<RepaintCause> {
+    self.read(|ctx| ctx.viewports.get(&ctx.viewport_id()).map(|v| v.repaint.prev_causes.clone())).unwrap_or_default()
+  }
 
-    /// Format the given shortcut in a human-readable way (e.g. `Ctrl+Shift+X`).
-    ///
-    /// Can be used to get the text for [`Button::shortcut_text`].
-    pub fn format_shortcut(&self, shortcut: &KeyboardShortcut) -> String {
-        let os = self.os();
-
-        let is_mac = matches!(os, OperatingSystem::Mac | OperatingSystem::IOS);
-
-        let can_show_symbols = || {
-            let ModifierNames {
-                alt,
-                ctrl,
-                shift,
-                mac_cmd,
-                ..
-            } = ModifierNames::SYMBOLS;
-
-            let font_id = TextStyle::Body.resolve(&self.style());
-            self.fonts(|f| {
-                let mut lock = f.lock();
-                let font = lock.fonts.font(&font_id);
-                font.has_glyphs(alt)
-                    && font.has_glyphs(ctrl)
-                    && font.has_glyphs(shift)
-                    && font.has_glyphs(mac_cmd)
-            })
-        };
-
-        if is_mac && can_show_symbols() {
-            shortcut.format(&ModifierNames::SYMBOLS, is_mac)
-        } else {
-            shortcut.format(&ModifierNames::NAMES, is_mac)
-        }
-    }
-
-    /// The current frame number for the current viewport.
-    ///
-    /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
-    ///
-    /// Between calls to [`Self::run`], this is the frame number of the coming frame.
-    pub fn frame_nr(&self) -> u64 {
-        self.frame_nr_for(self.viewport_id())
-    }
-
-    /// The current frame number.
-    ///
-    /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
-    ///
-    /// Between calls to [`Self::run`], this is the frame number of the coming frame.
-    pub fn frame_nr_for(&self, id: ViewportId) -> u64 {
-        self.read(|ctx| ctx.viewports.get(&id).map_or(0, |v| v.repaint.frame_nr))
-    }
-
-    /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
-    ///
-    /// If this is called at least once in a frame, then there will be another frame right after this.
-    /// Call as many times as you wish, only one repaint will be issued.
-    ///
-    /// To request repaint with a delay, use [`Self::request_repaint_after`].
-    ///
-    /// If called from outside the UI thread, the UI thread will wake up and run,
-    /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
-    /// (this will work on `eframe`).
-    ///
-    /// This will repaint the current viewport.
-    #[track_caller]
-    pub fn request_repaint(&self) {
-        self.request_repaint_of(self.viewport_id());
-    }
-
-    /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
-    ///
-    /// If this is called at least once in a frame, then there will be another frame right after this.
-    /// Call as many times as you wish, only one repaint will be issued.
-    ///
-    /// To request repaint with a delay, use [`Self::request_repaint_after_for`].
-    ///
-    /// If called from outside the UI thread, the UI thread will wake up and run,
-    /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
-    /// (this will work on `eframe`).
-    ///
-    /// This will repaint the specified viewport.
-    #[track_caller]
-    pub fn request_repaint_of(&self, id: ViewportId) {
-        let cause = RepaintCause::new();
-        self.write(|ctx| ctx.request_repaint(id, cause));
-    }
-
-    /// Request repaint after at most the specified duration elapses.
-    ///
-    /// The backend can chose to repaint sooner, for instance if some other code called
-    /// this method with a lower duration, or if new events arrived.
-    ///
-    /// The function can be multiple times, but only the *smallest* duration will be considered.
-    /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
-    /// after `1 second`
-    ///
-    /// This is primarily useful for applications who would like to save battery by avoiding wasted
-    /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
-    /// and outdated if it is not updated for too long.
-    ///
-    /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
-    /// resources repainting multiple times within the same second (when you have no input),
-    /// just calculate the difference of duration between current time and next second change,
-    /// and call this function, to make sure that you are displaying the latest updated time, but
-    /// not wasting resources on needless repaints within the same second.
-    ///
-    /// ### Quirk:
-    /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
-    /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
-    /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
-    /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
-    /// So, it's not that we are requesting repaint within X duration. We are rather timing out
-    /// during app idle time where we are not receiving any new input events.
-    ///
-    /// This repaints the current viewport
-    #[track_caller]
-    pub fn request_repaint_after(&self, duration: Duration) {
-        self.request_repaint_after_for(duration, self.viewport_id());
-    }
-
-    /// Repaint after this many seconds.
-    ///
-    /// See [`Self::request_repaint_after`] for details.
-    #[track_caller]
-    pub fn request_repaint_after_secs(&self, seconds: f32) {
-        if let Ok(duration) = std::time::Duration::try_from_secs_f32(seconds) {
-            self.request_repaint_after(duration);
-        }
-    }
-
-    /// Request repaint after at most the specified duration elapses.
-    ///
-    /// The backend can chose to repaint sooner, for instance if some other code called
-    /// this method with a lower duration, or if new events arrived.
-    ///
-    /// The function can be multiple times, but only the *smallest* duration will be considered.
-    /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
-    /// after `1 second`
-    ///
-    /// This is primarily useful for applications who would like to save battery by avoiding wasted
-    /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
-    /// and outdated if it is not updated for too long.
-    ///
-    /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
-    /// resources repainting multiple times within the same second (when you have no input),
-    /// just calculate the difference of duration between current time and next second change,
-    /// and call this function, to make sure that you are displaying the latest updated time, but
-    /// not wasting resources on needless repaints within the same second.
-    ///
-    /// ### Quirk:
-    /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
-    /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
-    /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
-    /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
-    /// So, it's not that we are requesting repaint within X duration. We are rather timing out
-    /// during app idle time where we are not receiving any new input events.
-    ///
-    /// This repaints the specified viewport
-    #[track_caller]
-    pub fn request_repaint_after_for(&self, duration: Duration, id: ViewportId) {
-        let cause = RepaintCause::new();
-        self.write(|ctx| ctx.request_repaint_after(duration, id, cause));
-    }
-
-    /// Was a repaint requested last frame for the current viewport?
-    #[must_use]
-    pub fn requested_repaint_last_frame(&self) -> bool {
-        self.requested_repaint_last_frame_for(&self.viewport_id())
-    }
-
-    /// Was a repaint requested last frame for the given viewport?
-    #[must_use]
-    pub fn requested_repaint_last_frame_for(&self, viewport_id: &ViewportId) -> bool {
-        self.read(|ctx| ctx.requested_immediate_repaint_prev_frame(viewport_id))
-    }
-
-    /// Has a repaint been requested for the current viewport?
-    #[must_use]
-    pub fn has_requested_repaint(&self) -> bool {
-        self.has_requested_repaint_for(&self.viewport_id())
-    }
-
-    /// Has a repaint been requested for the given viewport?
-    #[must_use]
-    pub fn has_requested_repaint_for(&self, viewport_id: &ViewportId) -> bool {
-        self.read(|ctx| ctx.has_requested_repaint(viewport_id))
-    }
-
-    /// Why are we repainting?
-    ///
-    /// This can be helpful in debugging why egui is constantly repainting.
-    pub fn repaint_causes(&self) -> Vec<RepaintCause> {
-        self.read(|ctx| {
-            ctx.viewports
-                .get(&ctx.viewport_id())
-                .map(|v| v.repaint.prev_causes.clone())
-        })
-        .unwrap_or_default()
-    }
-
-    /// For integrations: this callback will be called when an egui user calls [`Self::request_repaint`] or [`Self::request_repaint_after`].
-    ///
-    /// This lets you wake up a sleeping UI thread.
-    ///
-    /// Note that only one callback can be set. Any new call overrides the previous callback.
-    pub fn set_request_repaint_callback(
-        &self,
-        callback: impl Fn(RequestRepaintInfo) + Send + Sync + 'static,
-    ) {
-        let callback = Box::new(callback);
-        self.write(|ctx| ctx.request_repaint_callback = Some(callback));
-    }
+  /// For integrations: this callback will be called when an egui user calls [`Self::request_repaint`] or [`Self::request_repaint_after`].
+  ///
+  /// This lets you wake up a sleeping UI thread.
+  ///
+  /// Note that only one callback can be set. Any new call overrides the previous callback.
+  pub fn set_request_repaint_callback(&self, callback: impl Fn(RequestRepaintInfo) + Send + Sync + 'static) {
+    let callback = Box::new(callback);
+    self.write(|ctx| ctx.request_repaint_callback = Some(callback));
+  }
 }
 
 /// Callbacks
 impl Context {
-    /// Call the given callback at the start of each frame
-    /// of each viewport.
-    ///
-    /// This can be used for egui _plugins_.
-    /// See [`crate::debug_text`] for an example.
-    pub fn on_begin_frame(&self, debug_name: &'static str, cb: ContextCallback) {
-        let named_cb = NamedContextCallback {
-            debug_name,
-            callback: cb,
-        };
-        self.write(|ctx| ctx.plugins.on_begin_frame.push(named_cb));
-    }
+  /// Call the given callback at the start of each frame
+  /// of each viewport.
+  ///
+  /// This can be used for egui _plugins_.
+  /// See [`crate::debug_text`] for an example.
+  pub fn on_begin_frame(&self, debug_name: &'static str, cb: ContextCallback) {
+    let named_cb = NamedContextCallback { debug_name, callback: cb };
+    self.write(|ctx| ctx.plugins.on_begin_frame.push(named_cb));
+  }
 
-    /// Call the given callback at the end of each frame
-    /// of each viewport.
-    ///
-    /// This can be used for egui _plugins_.
-    /// See [`crate::debug_text`] for an example.
-    pub fn on_end_frame(&self, debug_name: &'static str, cb: ContextCallback) {
-        let named_cb = NamedContextCallback {
-            debug_name,
-            callback: cb,
-        };
-        self.write(|ctx| ctx.plugins.on_end_frame.push(named_cb));
-    }
+  /// Call the given callback at the end of each frame
+  /// of each viewport.
+  ///
+  /// This can be used for egui _plugins_.
+  /// See [`crate::debug_text`] for an example.
+  pub fn on_end_frame(&self, debug_name: &'static str, cb: ContextCallback) {
+    let named_cb = NamedContextCallback { debug_name, callback: cb };
+    self.write(|ctx| ctx.plugins.on_end_frame.push(named_cb));
+  }
 }
 
 impl Context {
-    /// Tell `egui` which fonts to use.
-    ///
-    /// The default `egui` fonts only support latin and cyrillic alphabets,
-    /// but you can call this to install additional fonts that support e.g. korean characters.
-    ///
-    /// The new fonts will become active at the start of the next frame.
-    pub fn set_fonts(&self, font_definitions: FontDefinitions) {
-        crate::profile_function!();
+  /// Tell `egui` which fonts to use.
+  ///
+  /// The default `egui` fonts only support latin and cyrillic alphabets,
+  /// but you can call this to install additional fonts that support e.g. korean characters.
+  ///
+  /// The new fonts will become active at the start of the next frame.
+  pub fn set_fonts(&self, font_definitions: FontDefinitions) {
+    crate::profile_function!();
 
-        let pixels_per_point = self.pixels_per_point();
+    let pixels_per_point = self.pixels_per_point();
 
-        let mut update_fonts = true;
+    let mut update_fonts = true;
 
-        self.read(|ctx| {
-            if let Some(current_fonts) = ctx.fonts.get(&pixels_per_point.into()) {
-                // NOTE: this comparison is expensive since it checks TTF data for equality
-                if current_fonts.lock().fonts.definitions() == &font_definitions {
-                    update_fonts = false; // no need to update
-                }
-            }
-        });
-
-        if update_fonts {
-            self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
+    self.read(|ctx| {
+      if let Some(current_fonts) = ctx.fonts.get(&pixels_per_point.into()) {
+        // NOTE: this comparison is expensive since it checks TTF data for equality
+        if current_fonts.lock().fonts.definitions() == &font_definitions {
+          update_fonts = false; // no need to update
         }
-    }
+      }
+    });
 
-    /// The [`Style`] used by all subsequent windows, panels etc.
-    pub fn style(&self) -> Arc<Style> {
-        self.options(|opt| opt.style.clone())
+    if update_fonts {
+      self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
     }
+  }
 
-    /// Mutate the [`Style`] used by all subsequent windows, panels etc.
-    ///
-    /// Example:
-    /// ```
-    /// # let mut ctx = egui::Context::default();
-    /// ctx.style_mut(|style| {
-    ///     style.spacing.item_spacing = egui::vec2(10.0, 20.0);
-    /// });
-    /// ```
-    pub fn style_mut(&self, mutate_style: impl FnOnce(&mut Style)) {
-        self.options_mut(|opt| mutate_style(std::sync::Arc::make_mut(&mut opt.style)));
+  /// The [`Style`] used by all subsequent windows, panels etc.
+  pub fn style(&self) -> Arc<Style> {
+    self.options(|opt| opt.style.clone())
+  }
+
+  /// Mutate the [`Style`] used by all subsequent windows, panels etc.
+  ///
+  /// Example:
+  /// ```
+  /// # let mut ctx = egui::Context::default();
+  /// ctx.style_mut(|style| {
+  ///     style.spacing.item_spacing = egui::vec2(10.0, 20.0);
+  /// });
+  /// ```
+  pub fn style_mut(&self, mutate_style: impl FnOnce(&mut Style)) {
+    self.options_mut(|opt| mutate_style(std::sync::Arc::make_mut(&mut opt.style)));
+  }
+
+  /// The [`Style`] used by all new windows, panels etc.
+  ///
+  /// You can also change this using [`Self::style_mut`]
+  ///
+  /// You can use [`Ui::style_mut`] to change the style of a single [`Ui`].
+  pub fn set_style(&self, style: impl Into<Arc<Style>>) {
+    self.options_mut(|opt| opt.style = style.into());
+  }
+
+  /// The [`Visuals`] used by all subsequent windows, panels etc.
+  ///
+  /// You can also use [`Ui::visuals_mut`] to change the visuals of a single [`Ui`].
+  ///
+  /// Example:
+  /// ```
+  /// # let mut ctx = egui::Context::default();
+  /// ctx.set_visuals(egui::Visuals::light()); // Switch to light mode
+  /// ```
+  pub fn set_visuals(&self, visuals: crate::Visuals) {
+    self.options_mut(|opt| std::sync::Arc::make_mut(&mut opt.style).visuals = visuals);
+  }
+
+  /// The number of physical pixels for each logical point.
+  ///
+  /// This is calculated as [`Self::zoom_factor`] * [`Self::native_pixels_per_point`]
+  #[inline(always)]
+  pub fn pixels_per_point(&self) -> f32 {
+    self.input(|i| i.pixels_per_point)
+  }
+
+  /// Set the number of physical pixels for each logical point.
+  /// Will become active at the start of the next frame.
+  ///
+  /// This will actually translate to a call to [`Self::set_zoom_factor`].
+  pub fn set_pixels_per_point(&self, pixels_per_point: f32) {
+    if pixels_per_point != self.pixels_per_point() {
+      self.set_zoom_factor(pixels_per_point / self.native_pixels_per_point().unwrap_or(1.0));
     }
+  }
 
-    /// The [`Style`] used by all new windows, panels etc.
-    ///
-    /// You can also change this using [`Self::style_mut`]
-    ///
-    /// You can use [`Ui::style_mut`] to change the style of a single [`Ui`].
-    pub fn set_style(&self, style: impl Into<Arc<Style>>) {
-        self.options_mut(|opt| opt.style = style.into());
-    }
+  /// The number of physical pixels for each logical point on this monitor.
+  ///
+  /// This is given as input to egui via [`ViewportInfo::native_pixels_per_point`]
+  /// and cannot be changed.
+  #[inline(always)]
+  pub fn native_pixels_per_point(&self) -> Option<f32> {
+    self.input(|i| i.viewport().native_pixels_per_point)
+  }
 
-    /// The [`Visuals`] used by all subsequent windows, panels etc.
-    ///
-    /// You can also use [`Ui::visuals_mut`] to change the visuals of a single [`Ui`].
-    ///
-    /// Example:
-    /// ```
-    /// # let mut ctx = egui::Context::default();
-    /// ctx.set_visuals(egui::Visuals::light()); // Switch to light mode
-    /// ```
-    pub fn set_visuals(&self, visuals: crate::Visuals) {
-        self.options_mut(|opt| std::sync::Arc::make_mut(&mut opt.style).visuals = visuals);
-    }
+  /// Global zoom factor of the UI.
+  ///
+  /// This is used to calculate the `pixels_per_point`
+  /// for the UI as `pixels_per_point = zoom_factor * native_pixels_per_point`.
+  ///
+  /// The default is 1.0.
+  /// Make larger to make everything larger.
+  #[inline(always)]
+  pub fn zoom_factor(&self) -> f32 {
+    self.options(|o| o.zoom_factor)
+  }
 
-    /// The number of physical pixels for each logical point.
-    ///
-    /// This is calculated as [`Self::zoom_factor`] * [`Self::native_pixels_per_point`]
-    #[inline(always)]
-    pub fn pixels_per_point(&self) -> f32 {
-        self.input(|i| i.pixels_per_point)
-    }
-
-    /// Set the number of physical pixels for each logical point.
-    /// Will become active at the start of the next frame.
-    ///
-    /// This will actually translate to a call to [`Self::set_zoom_factor`].
-    pub fn set_pixels_per_point(&self, pixels_per_point: f32) {
-        if pixels_per_point != self.pixels_per_point() {
-            self.set_zoom_factor(pixels_per_point / self.native_pixels_per_point().unwrap_or(1.0));
+  /// Sets zoom factor of the UI.
+  /// Will become active at the start of the next frame.
+  ///
+  /// Note that calling this will not update [`Self::zoom_factor`] until the end of the frame.
+  ///
+  /// This is used to calculate the `pixels_per_point`
+  /// for the UI as `pixels_per_point = zoom_fator * native_pixels_per_point`.
+  ///
+  /// The default is 1.0.
+  /// Make larger to make everything larger.
+  ///
+  /// It is better to call this than modifying
+  /// [`Options::zoom_factor`].
+  #[inline(always)]
+  pub fn set_zoom_factor(&self, zoom_factor: f32) {
+    let cause = RepaintCause::new();
+    self.write(|ctx| {
+      if ctx.memory.options.zoom_factor != zoom_factor {
+        ctx.new_zoom_factor = Some(zoom_factor);
+        for viewport_id in ctx.all_viewport_ids() {
+          ctx.request_repaint(viewport_id, cause.clone());
         }
-    }
+      }
+    });
+  }
 
-    /// The number of physical pixels for each logical point on this monitor.
-    ///
-    /// This is given as input to egui via [`ViewportInfo::native_pixels_per_point`]
-    /// and cannot be changed.
-    #[inline(always)]
-    pub fn native_pixels_per_point(&self) -> Option<f32> {
-        self.input(|i| i.viewport().native_pixels_per_point)
-    }
+  /// Useful for pixel-perfect rendering
+  #[inline]
+  pub(crate) fn round_to_pixel(&self, point: f32) -> f32 {
+    let pixels_per_point = self.pixels_per_point();
+    (point * pixels_per_point).round() / pixels_per_point
+  }
 
-    /// Global zoom factor of the UI.
-    ///
-    /// This is used to calculate the `pixels_per_point`
-    /// for the UI as `pixels_per_point = zoom_factor * native_pixels_per_point`.
-    ///
-    /// The default is 1.0.
-    /// Make larger to make everything larger.
-    #[inline(always)]
-    pub fn zoom_factor(&self) -> f32 {
-        self.options(|o| o.zoom_factor)
-    }
+  /// Useful for pixel-perfect rendering
+  #[inline]
+  pub(crate) fn round_pos_to_pixels(&self, pos: Pos2) -> Pos2 {
+    pos2(self.round_to_pixel(pos.x), self.round_to_pixel(pos.y))
+  }
 
-    /// Sets zoom factor of the UI.
-    /// Will become active at the start of the next frame.
-    ///
-    /// Note that calling this will not update [`Self::zoom_factor`] until the end of the frame.
-    ///
-    /// This is used to calculate the `pixels_per_point`
-    /// for the UI as `pixels_per_point = zoom_fator * native_pixels_per_point`.
-    ///
-    /// The default is 1.0.
-    /// Make larger to make everything larger.
-    ///
-    /// It is better to call this than modifying
-    /// [`Options::zoom_factor`].
-    #[inline(always)]
-    pub fn set_zoom_factor(&self, zoom_factor: f32) {
-        let cause = RepaintCause::new();
-        self.write(|ctx| {
-            if ctx.memory.options.zoom_factor != zoom_factor {
-                ctx.new_zoom_factor = Some(zoom_factor);
-                for viewport_id in ctx.all_viewport_ids() {
-                    ctx.request_repaint(viewport_id, cause.clone());
-                }
-            }
-        });
-    }
+  /// Useful for pixel-perfect rendering
+  #[inline]
+  pub(crate) fn round_vec_to_pixels(&self, vec: Vec2) -> Vec2 {
+    vec2(self.round_to_pixel(vec.x), self.round_to_pixel(vec.y))
+  }
 
-    /// Useful for pixel-perfect rendering
-    #[inline]
-    pub(crate) fn round_to_pixel(&self, point: f32) -> f32 {
-        let pixels_per_point = self.pixels_per_point();
-        (point * pixels_per_point).round() / pixels_per_point
-    }
+  /// Useful for pixel-perfect rendering
+  #[inline]
+  pub(crate) fn round_rect_to_pixels(&self, rect: Rect) -> Rect {
+    Rect { min: self.round_pos_to_pixels(rect.min), max: self.round_pos_to_pixels(rect.max) }
+  }
 
-    /// Useful for pixel-perfect rendering
-    #[inline]
-    pub(crate) fn round_pos_to_pixels(&self, pos: Pos2) -> Pos2 {
-        pos2(self.round_to_pixel(pos.x), self.round_to_pixel(pos.y))
-    }
+  /// Allocate a texture.
+  ///
+  /// This is for advanced users.
+  /// Most users should use [`crate::Ui::image`] or [`Self::try_load_texture`]
+  /// instead.
+  ///
+  /// In order to display an image you must convert it to a texture using this function.
+  /// The function will hand over the image data to the egui backend, which will
+  /// upload it to the GPU.
+  ///
+  /// ⚠️ Make sure to only call this ONCE for each image, i.e. NOT in your main GUI code.
+  /// The call is NOT immediate safe.
+  ///
+  /// The given name can be useful for later debugging, and will be visible if you call [`Self::texture_ui`].
+  ///
+  /// For how to load an image, see [`ImageData`] and [`ColorImage::from_rgba_unmultiplied`].
+  ///
+  /// ```
+  /// struct MyImage {
+  ///     texture: Option<egui::TextureHandle>,
+  /// }
+  ///
+  /// impl MyImage {
+  ///     fn ui(&mut self, ui: &mut egui::Ui) {
+  ///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+  ///             // Load the texture only once.
+  ///             ui.ctx().load_texture(
+  ///                 "my-image",
+  ///                 egui::ColorImage::example(),
+  ///                 Default::default()
+  ///             )
+  ///         });
+  ///
+  ///         // Show the image:
+  ///         ui.image((texture.id(), texture.size_vec2()));
+  ///     }
+  /// }
+  /// ```
+  ///
+  /// See also [`crate::ImageData`], [`crate::Ui::image`] and [`crate::Image`].
+  pub fn load_texture(
+    &self,
+    name: impl Into<String>,
+    image: impl Into<ImageData>,
+    options: TextureOptions,
+  ) -> TextureHandle {
+    let name = name.into();
+    let image = image.into();
+    let max_texture_side = self.input(|i| i.max_texture_side);
+    debug_assert!(
+      image.width() <= max_texture_side && image.height() <= max_texture_side,
+      "Texture {:?} has size {}x{}, but the maximum texture side is {}",
+      name,
+      image.width(),
+      image.height(),
+      max_texture_side
+    );
+    let tex_mngr = self.tex_manager();
+    let tex_id = tex_mngr.write().alloc(name, image, options);
+    TextureHandle::new(tex_mngr, tex_id)
+  }
 
-    /// Useful for pixel-perfect rendering
-    #[inline]
-    pub(crate) fn round_vec_to_pixels(&self, vec: Vec2) -> Vec2 {
-        vec2(self.round_to_pixel(vec.x), self.round_to_pixel(vec.y))
-    }
+  /// Low-level texture manager.
+  ///
+  /// In general it is easier to use [`Self::load_texture`] and [`TextureHandle`].
+  ///
+  /// You can show stats about the allocated textures using [`Self::texture_ui`].
+  pub fn tex_manager(&self) -> Arc<RwLock<epaint::textures::TextureManager>> {
+    self.read(|ctx| ctx.tex_manager.0.clone())
+  }
 
-    /// Useful for pixel-perfect rendering
-    #[inline]
-    pub(crate) fn round_rect_to_pixels(&self, rect: Rect) -> Rect {
-        Rect {
-            min: self.round_pos_to_pixels(rect.min),
-            max: self.round_pos_to_pixels(rect.max),
-        }
-    }
+  // ---------------------------------------------------------------------
 
-    /// Allocate a texture.
-    ///
-    /// This is for advanced users.
-    /// Most users should use [`crate::Ui::image`] or [`Self::try_load_texture`]
-    /// instead.
-    ///
-    /// In order to display an image you must convert it to a texture using this function.
-    /// The function will hand over the image data to the egui backend, which will
-    /// upload it to the GPU.
-    ///
-    /// ⚠️ Make sure to only call this ONCE for each image, i.e. NOT in your main GUI code.
-    /// The call is NOT immediate safe.
-    ///
-    /// The given name can be useful for later debugging, and will be visible if you call [`Self::texture_ui`].
-    ///
-    /// For how to load an image, see [`ImageData`] and [`ColorImage::from_rgba_unmultiplied`].
-    ///
-    /// ```
-    /// struct MyImage {
-    ///     texture: Option<egui::TextureHandle>,
-    /// }
-    ///
-    /// impl MyImage {
-    ///     fn ui(&mut self, ui: &mut egui::Ui) {
-    ///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
-    ///             // Load the texture only once.
-    ///             ui.ctx().load_texture(
-    ///                 "my-image",
-    ///                 egui::ColorImage::example(),
-    ///                 Default::default()
-    ///             )
-    ///         });
-    ///
-    ///         // Show the image:
-    ///         ui.image((texture.id(), texture.size_vec2()));
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// See also [`crate::ImageData`], [`crate::Ui::image`] and [`crate::Image`].
-    pub fn load_texture(
-        &self,
-        name: impl Into<String>,
-        image: impl Into<ImageData>,
-        options: TextureOptions,
-    ) -> TextureHandle {
-        let name = name.into();
-        let image = image.into();
-        let max_texture_side = self.input(|i| i.max_texture_side);
-        debug_assert!(
-            image.width() <= max_texture_side && image.height() <= max_texture_side,
-            "Texture {:?} has size {}x{}, but the maximum texture side is {}",
-            name,
-            image.width(),
-            image.height(),
-            max_texture_side
-        );
-        let tex_mngr = self.tex_manager();
-        let tex_id = tex_mngr.write().alloc(name, image, options);
-        TextureHandle::new(tex_mngr, tex_id)
-    }
+  /// Constrain the position of a window/area so it fits within the provided boundary.
+  pub fn constrain_window_rect_to_area(&self, window: Rect, area: Rect) -> Rect {
+    let mut pos = window.min;
 
-    /// Low-level texture manager.
-    ///
-    /// In general it is easier to use [`Self::load_texture`] and [`TextureHandle`].
-    ///
-    /// You can show stats about the allocated textures using [`Self::texture_ui`].
-    pub fn tex_manager(&self) -> Arc<RwLock<epaint::textures::TextureManager>> {
-        self.read(|ctx| ctx.tex_manager.0.clone())
-    }
+    // Constrain to screen, unless window is too large to fit:
+    let margin_x = (window.width() - area.width()).at_least(0.0);
+    let margin_y = (window.height() - area.height()).at_least(0.0);
 
-    // ---------------------------------------------------------------------
+    pos.x = pos.x.at_most(area.right() + margin_x - window.width()); // move left if needed
+    pos.x = pos.x.at_least(area.left() - margin_x); // move right if needed
+    pos.y = pos.y.at_most(area.bottom() + margin_y - window.height()); // move right if needed
+    pos.y = pos.y.at_least(area.top() - margin_y); // move down if needed
 
-    /// Constrain the position of a window/area so it fits within the provided boundary.
-    pub(crate) fn constrain_window_rect_to_area(&self, window: Rect, area: Rect) -> Rect {
-        let mut pos = window.min;
+    pos = self.round_pos_to_pixels(pos);
 
-        // Constrain to screen, unless window is too large to fit:
-        let margin_x = (window.width() - area.width()).at_least(0.0);
-        let margin_y = (window.height() - area.height()).at_least(0.0);
-
-        pos.x = pos.x.at_most(area.right() + margin_x - window.width()); // move left if needed
-        pos.x = pos.x.at_least(area.left() - margin_x); // move right if needed
-        pos.y = pos.y.at_most(area.bottom() + margin_y - window.height()); // move right if needed
-        pos.y = pos.y.at_least(area.top() - margin_y); // move down if needed
-
-        pos = self.round_pos_to_pixels(pos);
-
-        Rect::from_min_size(pos, window.size())
-    }
+    Rect::from_min_size(pos, window.size())
+  }
 }
 
 impl Context {
-    /// Call at the end of each frame.
-    #[must_use]
-    pub fn end_frame(&self) -> FullOutput {
-        crate::profile_function!();
+  /// Call at the end of each frame.
+  #[must_use]
+  pub fn end_frame(&self) -> FullOutput {
+    crate::profile_function!();
 
-        if self.options(|o| o.zoom_with_keyboard) {
-            crate::gui_zoom::zoom_with_keyboard(self);
-        }
-
-        // Plugins run just before the frame ends.
-        self.read(|ctx| ctx.plugins.clone()).on_end_frame(self);
-
-        #[cfg(debug_assertions)]
-        self.debug_painting();
-
-        self.write(|ctx| ctx.end_frame())
+    if self.options(|o| o.zoom_with_keyboard) {
+      crate::gui_zoom::zoom_with_keyboard(self);
     }
 
-    /// Called at the end of the frame.
+    // Plugins run just before the frame ends.
+    self.read(|ctx| ctx.plugins.clone()).on_end_frame(self);
+
     #[cfg(debug_assertions)]
-    fn debug_painting(&self) {
-        let paint_widget = |widget: &WidgetRect, text: &str, color: Color32| {
-            let rect = widget.interact_rect;
-            if rect.is_positive() {
-                let painter = Painter::new(self.clone(), widget.layer_id, Rect::EVERYTHING);
-                painter.debug_rect(rect, color, text);
-            }
-        };
+    self.debug_painting();
 
-        let paint_widget_id = |id: Id, text: &str, color: Color32| {
-            if let Some(widget) =
-                self.write(|ctx| ctx.viewport().this_frame.widgets.get(id).copied())
-            {
-                paint_widget(&widget, text, color);
-            }
-        };
+    self.write(|ctx| ctx.end_frame())
+  }
 
-        if self.style().debug.show_interactive_widgets {
-            // Show all interactive widgets:
-            let rects = self.write(|ctx| ctx.viewport().this_frame.widgets.clone());
-            for (layer_id, rects) in rects.layers() {
-                let painter = Painter::new(self.clone(), *layer_id, Rect::EVERYTHING);
-                for rect in rects {
-                    if rect.sense.interactive() {
-                        let (color, text) = if rect.sense.click && rect.sense.drag {
-                            (Color32::from_rgb(0x88, 0, 0x88), "click+drag")
-                        } else if rect.sense.click {
-                            (Color32::from_rgb(0x88, 0, 0), "click")
-                        } else if rect.sense.drag {
-                            (Color32::from_rgb(0, 0, 0x88), "drag")
-                        } else {
-                            // unreachable since we only show interactive
-                            (Color32::from_rgb(0, 0, 0x88), "hover")
-                        };
-                        painter.debug_rect(rect.interact_rect, color, text);
-                    }
-                }
-            }
+  /// Called at the end of the frame.
+  #[cfg(debug_assertions)]
+  fn debug_painting(&self) {
+    let paint_widget = |widget: &WidgetRect, text: &str, color: Color32| {
+      let rect = widget.interact_rect;
+      if rect.is_positive() {
+        let painter = Painter::new(self.clone(), widget.layer_id, Rect::EVERYTHING);
+        painter.debug_rect(rect, color, text);
+      }
+    };
 
-            // Show the ones actually interacted with:
-            {
-                let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
-                let InteractionSnapshot {
-                    clicked,
-                    long_touched: _,
-                    drag_started: _,
-                    dragged,
-                    drag_stopped: _,
-                    contains_pointer,
-                    hovered,
-                } = interact_widgets;
+    let paint_widget_id = |id: Id, text: &str, color: Color32| {
+      if let Some(widget) = self.write(|ctx| ctx.viewport().this_frame.widgets.get(id).copied()) {
+        paint_widget(&widget, text, color);
+      }
+    };
 
-                if true {
-                    for &id in &contains_pointer {
-                        paint_widget_id(id, "contains_pointer", Color32::BLUE);
-                    }
-
-                    let widget_rects = self.write(|w| w.viewport().this_frame.widgets.clone());
-
-                    let mut contains_pointer: Vec<Id> = contains_pointer.iter().copied().collect();
-                    contains_pointer.sort_by_key(|&id| {
-                        widget_rects
-                            .order(id)
-                            .map(|(layer_id, order_in_layer)| (layer_id.order, order_in_layer))
-                    });
-
-                    let mut debug_text = "Widgets in order:\n".to_owned();
-                    for id in contains_pointer {
-                        let mut widget_text = format!("{id:?}");
-                        if let Some(rect) = widget_rects.get(id) {
-                            widget_text += &format!(" {:?} {:?}", rect.rect, rect.sense);
-                        }
-                        if let Some(info) = widget_rects.info(id) {
-                            widget_text += &format!(" {info:?}");
-                        }
-                        debug_text += &format!("{widget_text}\n");
-                    }
-                    self.debug_text(debug_text);
-                }
-                if true {
-                    for widget in hovered {
-                        paint_widget_id(widget, "hovered", Color32::WHITE);
-                    }
-                }
-                for &widget in &clicked {
-                    paint_widget_id(widget, "clicked", Color32::RED);
-                }
-                for &widget in &dragged {
-                    paint_widget_id(widget, "dragged", Color32::GREEN);
-                }
-            }
+    if self.style().debug.show_interactive_widgets {
+      // Show all interactive widgets:
+      let rects = self.write(|ctx| ctx.viewport().this_frame.widgets.clone());
+      for (layer_id, rects) in rects.layers() {
+        let painter = Painter::new(self.clone(), *layer_id, Rect::EVERYTHING);
+        for rect in rects {
+          if rect.sense.interactive() {
+            let (color, text) = if rect.sense.click && rect.sense.drag {
+              (Color32::from_rgb(0x88, 0, 0x88), "click+drag")
+            } else if rect.sense.click {
+              (Color32::from_rgb(0x88, 0, 0), "click")
+            } else if rect.sense.drag {
+              (Color32::from_rgb(0, 0, 0x88), "drag")
+            } else {
+              // unreachable since we only show interactive
+              (Color32::from_rgb(0, 0, 0x88), "hover")
+            };
+            painter.debug_rect(rect.interact_rect, color, text);
+          }
         }
+      }
 
-        if self.style().debug.show_widget_hits {
-            let hits = self.write(|ctx| ctx.viewport().hits.clone());
-            let WidgetHits {
-                contains_pointer,
-                click,
-                drag,
-            } = hits;
+      // Show the ones actually interacted with:
+      {
+        let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
+        let InteractionSnapshot {
+          clicked,
+          long_touched: _,
+          drag_started: _,
+          dragged,
+          drag_stopped: _,
+          contains_pointer,
+          hovered,
+        } = interact_widgets;
 
-            if true {
-                for widget in &contains_pointer {
-                    paint_widget(widget, "contains_pointer", Color32::BLUE);
-                }
+        if true {
+          for &id in &contains_pointer {
+            paint_widget_id(id, "contains_pointer", Color32::BLUE);
+          }
+
+          let widget_rects = self.write(|w| w.viewport().this_frame.widgets.clone());
+
+          let mut contains_pointer: Vec<Id> = contains_pointer.iter().copied().collect();
+          contains_pointer.sort_by_key(|&id| {
+            widget_rects.order(id).map(|(layer_id, order_in_layer)| (layer_id.order, order_in_layer))
+          });
+
+          let mut debug_text = "Widgets in order:\n".to_owned();
+          for id in contains_pointer {
+            let mut widget_text = format!("{id:?}");
+            if let Some(rect) = widget_rects.get(id) {
+              widget_text += &format!(" {:?} {:?}", rect.rect, rect.sense);
             }
-            for widget in &click {
-                paint_widget(widget, "click", Color32::RED);
+            if let Some(info) = widget_rects.info(id) {
+              widget_text += &format!(" {info:?}");
             }
-            for widget in &drag {
-                paint_widget(widget, "drag", Color32::GREEN);
-            }
+            debug_text += &format!("{widget_text}\n");
+          }
+          self.debug_text(debug_text);
         }
-
-        if let Some(debug_rect) = self.frame_state_mut(|fs| fs.debug_rect.take()) {
-            debug_rect.paint(&self.debug_painter());
+        if true {
+          for widget in hovered {
+            paint_widget_id(widget, "hovered", Color32::WHITE);
+          }
         }
+        for &widget in &clicked {
+          paint_widget_id(widget, "clicked", Color32::RED);
+        }
+        for &widget in &dragged {
+          paint_widget_id(widget, "dragged", Color32::GREEN);
+        }
+      }
     }
+
+    if self.style().debug.show_widget_hits {
+      let hits = self.write(|ctx| ctx.viewport().hits.clone());
+      let WidgetHits { contains_pointer, click, drag } = hits;
+
+      if true {
+        for widget in &contains_pointer {
+          paint_widget(widget, "contains_pointer", Color32::BLUE);
+        }
+      }
+      for widget in &click {
+        paint_widget(widget, "click", Color32::RED);
+      }
+      for widget in &drag {
+        paint_widget(widget, "drag", Color32::GREEN);
+      }
+    }
+
+    if let Some(debug_rect) = self.frame_state_mut(|fs| fs.debug_rect.take()) {
+      debug_rect.paint(&self.debug_painter());
+    }
+  }
 }
 
 impl ContextImpl {
-    fn end_frame(&mut self) -> FullOutput {
-        let ended_viewport_id = self.viewport_id();
-        let viewport = self.viewports.entry(ended_viewport_id).or_default();
-        let pixels_per_point = viewport.input.pixels_per_point;
+  fn end_frame(&mut self) -> FullOutput {
+    let ended_viewport_id = self.viewport_id();
+    let viewport = self.viewports.entry(ended_viewport_id).or_default();
+    let pixels_per_point = viewport.input.pixels_per_point;
 
-        viewport.repaint.frame_nr += 1;
+    viewport.repaint.frame_nr += 1;
 
-        self.memory.end_frame(&viewport.this_frame.used_ids);
+    self.memory.end_frame(&viewport.this_frame.used_ids);
 
-        if let Some(fonts) = self.fonts.get(&pixels_per_point.into()) {
-            let tex_mngr = &mut self.tex_manager.0.write();
-            if let Some(font_image_delta) = fonts.font_image_delta() {
-                // A partial font atlas update, e.g. a new glyph has been entered.
-                tex_mngr.set(TextureId::default(), font_image_delta);
-            }
+    if let Some(fonts) = self.fonts.get(&pixels_per_point.into()) {
+      let tex_mngr = &mut self.tex_manager.0.write();
+      if let Some(font_image_delta) = fonts.font_image_delta() {
+        // A partial font atlas update, e.g. a new glyph has been entered.
+        tex_mngr.set(TextureId::default(), font_image_delta);
+      }
 
-            if 1 < self.fonts.len() {
-                // We have multiple different `pixels_per_point`,
-                // e.g. because we have many viewports spread across
-                // monitors with different DPI scaling.
-                // All viewports share the same texture namespace and renderer,
-                // so the all use `TextureId::default()` for the font texture.
-                // This is a problem.
-                // We solve this with a hack: we always upload the full font atlas
-                // every frame, for all viewports.
-                // This ensures it is up-to-date, solving
-                // https://github.com/emilk/egui/issues/3664
-                // at the cost of a lot of performance.
-                // (This will override any smaller delta that was uploaded above.)
-                crate::profile_scope!("full_font_atlas_update");
-                let full_delta = ImageDelta::full(fonts.image(), TextureAtlas::texture_options());
-                tex_mngr.set(TextureId::default(), full_delta);
-            }
-        }
-
-        // Inform the backend of all textures that have been updated (including font atlas).
-        let textures_delta = self.tex_manager.0.write().take_delta();
-
-        #[cfg_attr(not(feature = "accesskit"), allow(unused_mut))]
-        let mut platform_output: PlatformOutput = std::mem::take(&mut viewport.output);
-
-        #[cfg(feature = "accesskit")]
-        {
-            crate::profile_scope!("accesskit");
-            let state = viewport.this_frame.accesskit_state.take();
-            if let Some(state) = state {
-                let root_id = crate::accesskit_root_id().accesskit_id();
-                let nodes = {
-                    state
-                        .node_builders
-                        .into_iter()
-                        .map(|(id, builder)| {
-                            (
-                                id.accesskit_id(),
-                                builder.build(&mut self.accesskit_node_classes),
-                            )
-                        })
-                        .collect()
-                };
-                let focus_id = self
-                    .memory
-                    .focused()
-                    .map_or(root_id, |id| id.accesskit_id());
-                platform_output.accesskit_update = Some(accesskit::TreeUpdate {
-                    nodes,
-                    tree: Some(accesskit::Tree::new(root_id)),
-                    focus: focus_id,
-                });
-            }
-        }
-
-        let shapes = viewport
-            .graphics
-            .drain(self.memory.areas().order(), &self.memory.layer_transforms);
-
-        let mut repaint_needed = false;
-
-        if self.memory.options.repaint_on_widget_change {
-            crate::profile_function!("compare-widget-rects");
-            if viewport.prev_frame.widgets != viewport.this_frame.widgets {
-                repaint_needed = true; // Some widget has moved
-            }
-        }
-
-        std::mem::swap(&mut viewport.prev_frame, &mut viewport.this_frame);
-
-        if repaint_needed {
-            self.request_repaint(ended_viewport_id, RepaintCause::new());
-        } else if let Some(delay) = viewport.input.wants_repaint_after() {
-            self.request_repaint_after(delay, ended_viewport_id, RepaintCause::new());
-        }
-
-        //  -------------------
-
-        let all_viewport_ids = self.all_viewport_ids();
-
-        self.last_viewport = ended_viewport_id;
-
-        self.viewports.retain(|&id, viewport| {
-            let parent = *self.viewport_parents.entry(id).or_default();
-
-            if !all_viewport_ids.contains(&parent) {
-                #[cfg(feature = "log")]
-                log::debug!(
-                    "Removing viewport {:?} ({:?}): the parent is gone",
-                    id,
-                    viewport.builder.title
-                );
-
-                return false;
-            }
-
-            let is_our_child = parent == ended_viewport_id && id != ViewportId::ROOT;
-            if is_our_child {
-                if !viewport.used {
-                    #[cfg(feature = "log")]
-                    log::debug!(
-                        "Removing viewport {:?} ({:?}): it was never used this frame",
-                        id,
-                        viewport.builder.title
-                    );
-
-                    return false; // Only keep children that have been updated this frame
-                }
-
-                viewport.used = false; // reset so we can check again next frame
-            }
-
-            true
-        });
-
-        // If we are an immediate viewport, this will resume the previous viewport.
-        self.viewport_stack.pop();
-
-        // The last viewport is not necessarily the root viewport,
-        // just the top _immediate_ viewport.
-        let is_last = self.viewport_stack.is_empty();
-
-        let viewport_output = self
-            .viewports
-            .iter_mut()
-            .map(|(&id, viewport)| {
-                let parent = *self.viewport_parents.entry(id).or_default();
-                let commands = if is_last {
-                    // Let the primary immediate viewport handle the commands of its children too.
-                    // This can make things easier for the backend, as otherwise we may get commands
-                    // that affect a viewport while its egui logic is running.
-                    std::mem::take(&mut viewport.commands)
-                } else {
-                    vec![]
-                };
-
-                (
-                    id,
-                    ViewportOutput {
-                        parent,
-                        class: viewport.class,
-                        builder: viewport.builder.clone(),
-                        viewport_ui_cb: viewport.viewport_ui_cb.clone(),
-                        commands,
-                        repaint_delay: viewport.repaint.repaint_delay,
-                    },
-                )
-            })
-            .collect();
-
-        if is_last {
-            // Remove dead viewports:
-            self.viewports.retain(|id, _| all_viewport_ids.contains(id));
-            self.viewport_parents
-                .retain(|id, _| all_viewport_ids.contains(id));
-        } else {
-            let viewport_id = self.viewport_id();
-            self.memory.set_viewport_id(viewport_id);
-        }
-
-        let active_pixels_per_point: std::collections::BTreeSet<OrderedFloat<f32>> = self
-            .viewports
-            .values()
-            .map(|v| v.input.pixels_per_point.into())
-            .collect();
-        self.fonts.retain(|pixels_per_point, _| {
-            if active_pixels_per_point.contains(pixels_per_point) {
-                true
-            } else {
-                #[cfg(feature = "log")]
-                log::trace!(
-                    "Freeing Fonts with pixels_per_point={} because it is no longer needed",
-                    pixels_per_point.into_inner()
-                );
-                false
-            }
-        });
-
-        FullOutput {
-            platform_output,
-            textures_delta,
-            shapes,
-            pixels_per_point,
-            viewport_output,
-        }
+      if 1 < self.fonts.len() {
+        // We have multiple different `pixels_per_point`,
+        // e.g. because we have many viewports spread across
+        // monitors with different DPI scaling.
+        // All viewports share the same texture namespace and renderer,
+        // so the all use `TextureId::default()` for the font texture.
+        // This is a problem.
+        // We solve this with a hack: we always upload the full font atlas
+        // every frame, for all viewports.
+        // This ensures it is up-to-date, solving
+        // https://github.com/emilk/egui/issues/3664
+        // at the cost of a lot of performance.
+        // (This will override any smaller delta that was uploaded above.)
+        crate::profile_scope!("full_font_atlas_update");
+        let full_delta = ImageDelta::full(fonts.image(), TextureAtlas::texture_options());
+        tex_mngr.set(TextureId::default(), full_delta);
+      }
     }
+
+    // Inform the backend of all textures that have been updated (including font atlas).
+    let textures_delta = self.tex_manager.0.write().take_delta();
+
+    #[cfg_attr(not(feature = "accesskit"), allow(unused_mut))]
+    let mut platform_output: PlatformOutput = std::mem::take(&mut viewport.output);
+
+    #[cfg(feature = "accesskit")]
+    {
+      crate::profile_scope!("accesskit");
+      let state = viewport.this_frame.accesskit_state.take();
+      if let Some(state) = state {
+        let root_id = crate::accesskit_root_id().accesskit_id();
+        let nodes = {
+          state
+            .node_builders
+            .into_iter()
+            .map(|(id, builder)| (id.accesskit_id(), builder.build(&mut self.accesskit_node_classes)))
+            .collect()
+        };
+        let focus_id = self.memory.focused().map_or(root_id, |id| id.accesskit_id());
+        platform_output.accesskit_update =
+          Some(accesskit::TreeUpdate { nodes, tree: Some(accesskit::Tree::new(root_id)), focus: focus_id });
+      }
+    }
+
+    let shapes = viewport.graphics.drain(self.memory.areas().order(), &self.memory.layer_transforms);
+
+    let mut repaint_needed = false;
+
+    if self.memory.options.repaint_on_widget_change {
+      crate::profile_function!("compare-widget-rects");
+      if viewport.prev_frame.widgets != viewport.this_frame.widgets {
+        repaint_needed = true; // Some widget has moved
+      }
+    }
+
+    std::mem::swap(&mut viewport.prev_frame, &mut viewport.this_frame);
+
+    if repaint_needed {
+      self.request_repaint(ended_viewport_id, RepaintCause::new());
+    } else if let Some(delay) = viewport.input.wants_repaint_after() {
+      self.request_repaint_after(delay, ended_viewport_id, RepaintCause::new());
+    }
+
+    //  -------------------
+
+    let all_viewport_ids = self.all_viewport_ids();
+
+    self.last_viewport = ended_viewport_id;
+
+    self.viewports.retain(|&id, viewport| {
+      let parent = *self.viewport_parents.entry(id).or_default();
+
+      if !all_viewport_ids.contains(&parent) {
+        #[cfg(feature = "log")]
+        log::debug!("Removing viewport {:?} ({:?}): the parent is gone", id, viewport.builder.title);
+
+        return false;
+      }
+
+      let is_our_child = parent == ended_viewport_id && id != ViewportId::ROOT;
+      if is_our_child {
+        if !viewport.used {
+          #[cfg(feature = "log")]
+          log::debug!("Removing viewport {:?} ({:?}): it was never used this frame", id, viewport.builder.title);
+
+          return false; // Only keep children that have been updated this frame
+        }
+
+        viewport.used = false; // reset so we can check again next frame
+      }
+
+      true
+    });
+
+    // If we are an immediate viewport, this will resume the previous viewport.
+    self.viewport_stack.pop();
+
+    // The last viewport is not necessarily the root viewport,
+    // just the top _immediate_ viewport.
+    let is_last = self.viewport_stack.is_empty();
+
+    let viewport_output = self
+      .viewports
+      .iter_mut()
+      .map(|(&id, viewport)| {
+        let parent = *self.viewport_parents.entry(id).or_default();
+        let commands = if is_last {
+          // Let the primary immediate viewport handle the commands of its children too.
+          // This can make things easier for the backend, as otherwise we may get commands
+          // that affect a viewport while its egui logic is running.
+          std::mem::take(&mut viewport.commands)
+        } else {
+          vec![]
+        };
+
+        (
+          id,
+          ViewportOutput {
+            parent,
+            class: viewport.class,
+            builder: viewport.builder.clone(),
+            viewport_ui_cb: viewport.viewport_ui_cb.clone(),
+            commands,
+            repaint_delay: viewport.repaint.repaint_delay,
+          },
+        )
+      })
+      .collect();
+
+    if is_last {
+      // Remove dead viewports:
+      self.viewports.retain(|id, _| all_viewport_ids.contains(id));
+      self.viewport_parents.retain(|id, _| all_viewport_ids.contains(id));
+    } else {
+      let viewport_id = self.viewport_id();
+      self.memory.set_viewport_id(viewport_id);
+    }
+
+    let active_pixels_per_point: std::collections::BTreeSet<OrderedFloat<f32>> =
+      self.viewports.values().map(|v| v.input.pixels_per_point.into()).collect();
+    self.fonts.retain(|pixels_per_point, _| {
+      if active_pixels_per_point.contains(pixels_per_point) {
+        true
+      } else {
+        #[cfg(feature = "log")]
+        log::trace!(
+          "Freeing Fonts with pixels_per_point={} because it is no longer needed",
+          pixels_per_point.into_inner()
+        );
+        false
+      }
+    });
+
+    FullOutput { platform_output, textures_delta, shapes, pixels_per_point, viewport_output }
+  }
 }
 
 impl Context {
-    /// Tessellate the given shapes into triangle meshes.
-    ///
-    /// `pixels_per_point` is used for feathering (anti-aliasing).
-    /// For this you can use [`FullOutput::pixels_per_point`], [`Self::pixels_per_point`],
-    /// or whatever is appropriate for your viewport.
-    pub fn tessellate(
-        &self,
-        shapes: Vec<ClippedShape>,
-        pixels_per_point: f32,
-    ) -> Vec<ClippedPrimitive> {
-        crate::profile_function!();
+  /// Tessellate the given shapes into triangle meshes.
+  ///
+  /// `pixels_per_point` is used for feathering (anti-aliasing).
+  /// For this you can use [`FullOutput::pixels_per_point`], [`Self::pixels_per_point`],
+  /// or whatever is appropriate for your viewport.
+  pub fn tessellate(&self, shapes: Vec<ClippedShape>, pixels_per_point: f32) -> Vec<ClippedPrimitive> {
+    crate::profile_function!();
 
-        // A tempting optimization is to reuse the tessellation from last frame if the
-        // shapes are the same, but just comparing the shapes takes about 50% of the time
-        // it takes to tessellate them, so it is not a worth optimization.
+    // A tempting optimization is to reuse the tessellation from last frame if the
+    // shapes are the same, but just comparing the shapes takes about 50% of the time
+    // it takes to tessellate them, so it is not a worth optimization.
 
-        self.write(|ctx| {
-            let tessellation_options = ctx.memory.options.tessellation_options;
-            let texture_atlas = ctx
-                .fonts
-                .get(&pixels_per_point.into())
-                .expect("tessellate called with a different pixels_per_point than the font atlas was created with. \
-                         You should use egui::FullOutput::pixels_per_point when tessellating.")
-                .texture_atlas();
-            let (font_tex_size, prepared_discs) = {
-                let atlas = texture_atlas.lock();
-                (atlas.size(), atlas.prepared_discs())
-            };
+    self.write(|ctx| {
+      let tessellation_options = ctx.memory.options.tessellation_options;
+      let texture_atlas = ctx
+        .fonts
+        .get(&pixels_per_point.into())
+        .expect(
+          "tessellate called with a different pixels_per_point than the font atlas was created with. \
+                         You should use egui::FullOutput::pixels_per_point when tessellating.",
+        )
+        .texture_atlas();
+      let (font_tex_size, prepared_discs) = {
+        let atlas = texture_atlas.lock();
+        (atlas.size(), atlas.prepared_discs())
+      };
 
-            let paint_stats = PaintStats::from_shapes(&shapes);
-            let clipped_primitives = {
-                crate::profile_scope!("tessellator::tessellate_shapes");
-                tessellator::Tessellator::new(
-                    pixels_per_point,
-                    tessellation_options,
-                    font_tex_size,
-                    prepared_discs,
-                )
-                .tessellate_shapes(shapes)
-            };
-            ctx.paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
-            clipped_primitives
-        })
-    }
+      let paint_stats = PaintStats::from_shapes(&shapes);
+      let clipped_primitives = {
+        crate::profile_scope!("tessellator::tessellate_shapes");
+        tessellator::Tessellator::new(pixels_per_point, tessellation_options, font_tex_size, prepared_discs)
+          .tessellate_shapes(shapes)
+      };
+      ctx.paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
+      clipped_primitives
+    })
+  }
 
-    // ---------------------------------------------------------------------
+  // ---------------------------------------------------------------------
 
-    /// Position and size of the egui area.
-    pub fn screen_rect(&self) -> Rect {
-        self.input(|i| i.screen_rect())
-    }
+  /// Position and size of the egui area.
+  pub fn screen_rect(&self) -> Rect {
+    self.input(|i| i.screen_rect())
+  }
 
-    /// How much space is still available after panels has been added.
-    ///
-    /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
-    /// This is also the area to which windows are constrained.
-    pub fn available_rect(&self) -> Rect {
-        self.frame_state(|s| s.available_rect())
-    }
+  /// How much space is still available after panels has been added.
+  ///
+  /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
+  /// This is also the area to which windows are constrained.
+  pub fn available_rect(&self) -> Rect {
+    self.frame_state(|s| s.available_rect())
+  }
 
-    /// How much space is used by panels and windows.
-    pub fn used_rect(&self) -> Rect {
-        self.write(|ctx| {
-            let mut used = ctx.viewport().this_frame.used_by_panels;
-            for (_id, window) in ctx.memory.areas().visible_windows() {
-                used = used.union(window.rect());
-            }
-            used
-        })
-    }
+  /// How much space is used by panels and windows.
+  pub fn used_rect(&self) -> Rect {
+    self.write(|ctx| {
+      let mut used = ctx.viewport().this_frame.used_by_panels;
+      for (_id, window) in ctx.memory.areas().visible_windows() {
+        used = used.union(window.rect());
+      }
+      used
+    })
+  }
 
-    /// How much space is used by panels and windows.
-    ///
-    /// You can shrink your egui area to this size and still fit all egui components.
-    pub fn used_size(&self) -> Vec2 {
-        self.used_rect().max - Pos2::ZERO
-    }
+  /// How much space is used by panels and windows.
+  ///
+  /// You can shrink your egui area to this size and still fit all egui components.
+  pub fn used_size(&self) -> Vec2 {
+    self.used_rect().max - Pos2::ZERO
+  }
 
-    // ---------------------------------------------------------------------
+  // ---------------------------------------------------------------------
 
-    /// Is the pointer (mouse/touch) over any egui area?
-    pub fn is_pointer_over_area(&self) -> bool {
-        let pointer_pos = self.input(|i| i.pointer.interact_pos());
-        if let Some(pointer_pos) = pointer_pos {
-            if let Some(layer) = self.layer_id_at(pointer_pos) {
-                if layer.order == Order::Background {
-                    !self.frame_state(|state| state.unused_rect.contains(pointer_pos))
-                } else {
-                    true
-                }
-            } else {
-                false
-            }
+  /// Is the pointer (mouse/touch) over any egui area?
+  pub fn is_pointer_over_area(&self) -> bool {
+    let pointer_pos = self.input(|i| i.pointer.interact_pos());
+    if let Some(pointer_pos) = pointer_pos {
+      if let Some(layer) = self.layer_id_at(pointer_pos) {
+        if layer.order == Order::Background {
+          !self.frame_state(|state| state.unused_rect.contains(pointer_pos))
         } else {
-            false
+          true
         }
+      } else {
+        false
+      }
+    } else {
+      false
     }
+  }
 
-    /// True if egui is currently interested in the pointer (mouse or touch).
-    ///
-    /// Could be the pointer is hovering over a [`Window`] or the user is dragging a widget.
-    /// If `false`, the pointer is outside of any egui area and so
-    /// you may be interested in what it is doing (e.g. controlling your game).
-    /// Returns `false` if a drag started outside of egui and then moved over an egui area.
-    pub fn wants_pointer_input(&self) -> bool {
-        self.is_using_pointer()
-            || (self.is_pointer_over_area() && !self.input(|i| i.pointer.any_down()))
-    }
+  /// True if egui is currently interested in the pointer (mouse or touch).
+  ///
+  /// Could be the pointer is hovering over a [`Window`] or the user is dragging a widget.
+  /// If `false`, the pointer is outside of any egui area and so
+  /// you may be interested in what it is doing (e.g. controlling your game).
+  /// Returns `false` if a drag started outside of egui and then moved over an egui area.
+  pub fn wants_pointer_input(&self) -> bool {
+    self.is_using_pointer() || (self.is_pointer_over_area() && !self.input(|i| i.pointer.any_down()))
+  }
 
-    /// Is egui currently using the pointer position (e.g. dragging a slider)?
-    ///
-    /// NOTE: this will return `false` if the pointer is just hovering over an egui area.
-    pub fn is_using_pointer(&self) -> bool {
-        self.memory(|m| m.interaction().is_using_pointer())
-    }
+  /// Is egui currently using the pointer position (e.g. dragging a slider)?
+  ///
+  /// NOTE: this will return `false` if the pointer is just hovering over an egui area.
+  pub fn is_using_pointer(&self) -> bool {
+    self.memory(|m| m.interaction().is_using_pointer())
+  }
 
-    /// If `true`, egui is currently listening on text input (e.g. typing text in a [`TextEdit`]).
-    pub fn wants_keyboard_input(&self) -> bool {
-        self.memory(|m| m.focused().is_some())
-    }
+  /// If `true`, egui is currently listening on text input (e.g. typing text in a [`TextEdit`]).
+  pub fn wants_keyboard_input(&self) -> bool {
+    self.memory(|m| m.focused().is_some())
+  }
 
-    /// Highlight this widget, to make it look like it is hovered, even if it isn't.
-    ///
-    /// The highlight takes on frame to take effect if you call this after the widget has been fully rendered.
-    ///
-    /// See also [`Response::highlight`].
-    pub fn highlight_widget(&self, id: Id) {
-        self.frame_state_mut(|fs| fs.highlight_next_frame.insert(id));
-    }
+  /// Highlight this widget, to make it look like it is hovered, even if it isn't.
+  ///
+  /// The highlight takes on frame to take effect if you call this after the widget has been fully rendered.
+  ///
+  /// See also [`Response::highlight`].
+  pub fn highlight_widget(&self, id: Id) {
+    self.frame_state_mut(|fs| fs.highlight_next_frame.insert(id));
+  }
 
-    /// Is an egui context menu open?
-    pub fn is_context_menu_open(&self) -> bool {
-        self.data(|d| {
-            d.get_temp::<crate::menu::BarState>(menu::CONTEXT_MENU_ID_STR.into())
-                .map_or(false, |state| state.has_root())
-        })
-    }
+  /// Is an egui context menu open?
+  pub fn is_context_menu_open(&self) -> bool {
+    self.data(|d| {
+      d.get_temp::<crate::menu::BarState>(menu::CONTEXT_MENU_ID_STR.into()).map_or(false, |state| state.has_root())
+    })
+  }
 }
 
 // Ergonomic methods to forward some calls often used in 'if let' without holding the borrow
 impl Context {
-    /// Latest reported pointer position.
-    ///
-    /// When tapping a touch screen, this will be `None`.
-    #[inline(always)]
-    pub fn pointer_latest_pos(&self) -> Option<Pos2> {
-        self.input(|i| i.pointer.latest_pos())
-    }
+  /// Latest reported pointer position.
+  ///
+  /// When tapping a touch screen, this will be `None`.
+  #[inline(always)]
+  pub fn pointer_latest_pos(&self) -> Option<Pos2> {
+    self.input(|i| i.pointer.latest_pos())
+  }
 
-    /// If it is a good idea to show a tooltip, where is pointer?
-    #[inline(always)]
-    pub fn pointer_hover_pos(&self) -> Option<Pos2> {
-        self.input(|i| i.pointer.hover_pos())
-    }
+  /// If it is a good idea to show a tooltip, where is pointer?
+  #[inline(always)]
+  pub fn pointer_hover_pos(&self) -> Option<Pos2> {
+    self.input(|i| i.pointer.hover_pos())
+  }
 
-    /// If you detect a click or drag and wants to know where it happened, use this.
-    ///
-    /// Latest position of the mouse, but ignoring any [`Event::PointerGone`]
-    /// if there were interactions this frame.
-    /// When tapping a touch screen, this will be the location of the touch.
-    #[inline(always)]
-    pub fn pointer_interact_pos(&self) -> Option<Pos2> {
-        self.input(|i| i.pointer.interact_pos())
-    }
+  /// If you detect a click or drag and wants to know where it happened, use this.
+  ///
+  /// Latest position of the mouse, but ignoring any [`Event::PointerGone`]
+  /// if there were interactions this frame.
+  /// When tapping a touch screen, this will be the location of the touch.
+  #[inline(always)]
+  pub fn pointer_interact_pos(&self) -> Option<Pos2> {
+    self.input(|i| i.pointer.interact_pos())
+  }
 
-    /// Calls [`InputState::multi_touch`].
-    pub fn multi_touch(&self) -> Option<MultiTouchInfo> {
-        self.input(|i| i.multi_touch())
-    }
+  /// Calls [`InputState::multi_touch`].
+  pub fn multi_touch(&self) -> Option<MultiTouchInfo> {
+    self.input(|i| i.multi_touch())
+  }
 }
 
 impl Context {
-    /// Transform the graphics of the given layer.
-    ///
-    /// This will also affect input.
-    ///
-    /// This is a sticky setting, remembered from one frame to the next.
-    ///
-    /// Can be used to implement pan and zoom (see relevant demo).
-    ///
-    /// For a temporary transform, use [`Self::transform_layer_shapes`] instead.
-    pub fn set_transform_layer(&self, layer_id: LayerId, transform: TSTransform) {
-        self.memory_mut(|m| {
-            if transform == TSTransform::IDENTITY {
-                m.layer_transforms.remove(&layer_id)
-            } else {
-                m.layer_transforms.insert(layer_id, transform)
-            }
-        });
+  /// Transform the graphics of the given layer.
+  ///
+  /// This will also affect input.
+  ///
+  /// This is a sticky setting, remembered from one frame to the next.
+  ///
+  /// Can be used to implement pan and zoom (see relevant demo).
+  ///
+  /// For a temporary transform, use [`Self::transform_layer_shapes`] instead.
+  pub fn set_transform_layer(&self, layer_id: LayerId, transform: TSTransform) {
+    self.memory_mut(|m| {
+      if transform == TSTransform::IDENTITY {
+        m.layer_transforms.remove(&layer_id)
+      } else {
+        m.layer_transforms.insert(layer_id, transform)
+      }
+    });
+  }
+
+  /// Move all the graphics at the given layer.
+  ///
+  /// Is used to implement drag-and-drop preview.
+  ///
+  /// This only applied to the existing graphics at the layer, not to new graphics added later.
+  ///
+  /// For a persistent transform, use [`Self::set_transform_layer`] instead.
+  #[deprecated = "Use `transform_layer_shapes` instead"]
+  pub fn translate_layer(&self, layer_id: LayerId, delta: Vec2) {
+    if delta != Vec2::ZERO {
+      let transform = emath::TSTransform::from_translation(delta);
+      self.transform_layer_shapes(layer_id, transform);
+    }
+  }
+
+  /// Transform all the graphics at the given layer.
+  ///
+  /// Is used to implement drag-and-drop preview.
+  ///
+  /// This only applied to the existing graphics at the layer, not to new graphics added later.
+  ///
+  /// For a persistent transform, use [`Self::set_transform_layer`] instead.
+  pub fn transform_layer_shapes(&self, layer_id: LayerId, transform: TSTransform) {
+    if transform != TSTransform::IDENTITY {
+      self.graphics_mut(|g| g.entry(layer_id).transform(transform));
+    }
+  }
+
+  /// Top-most layer at the given position.
+  pub fn layer_id_at(&self, pos: Pos2) -> Option<LayerId> {
+    self.memory(|mem| mem.layer_id_at(pos))
+  }
+
+  /// Moves the given area to the top in its [`Order`].
+  ///
+  /// [`Area`]:s and [`Window`]:s also do this automatically when being clicked on or interacted with.
+  pub fn move_to_top(&self, layer_id: LayerId) {
+    self.memory_mut(|mem| mem.areas_mut().move_to_top(layer_id));
+  }
+
+  /// Mark the `child` layer as a sublayer of `parent`.
+  ///
+  /// Sublayers are moved directly above the parent layer at the end of the frame. This is mainly
+  /// intended for adding a new [`Area`] inside a [`Window`].
+  ///
+  /// This currently only supports one level of nesting. If `parent` is a sublayer of another
+  /// layer, the behavior is unspecified.
+  pub fn set_sublayer(&self, parent: LayerId, child: LayerId) {
+    self.memory_mut(|mem| mem.areas_mut().set_sublayer(parent, child));
+  }
+
+  /// Retrieve the [`LayerId`] of the top level windows.
+  pub fn top_layer_id(&self) -> Option<LayerId> {
+    self.memory(|mem| mem.areas().top_layer_id(Order::Middle))
+  }
+
+  /// Does the given rectangle contain the mouse pointer?
+  ///
+  /// Will return false if some other area is covering the given layer.
+  ///
+  /// The given rectangle is assumed to have been clipped by its parent clip rect.
+  ///
+  /// See also [`Response::contains_pointer`].
+  pub fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
+    let rect = if let Some(transform) = self.memory(|m| m.layer_transforms.get(&layer_id).copied()) {
+      transform * rect
+    } else {
+      rect
+    };
+    if !rect.is_positive() {
+      return false;
     }
 
-    /// Move all the graphics at the given layer.
-    ///
-    /// Is used to implement drag-and-drop preview.
-    ///
-    /// This only applied to the existing graphics at the layer, not to new graphics added later.
-    ///
-    /// For a persistent transform, use [`Self::set_transform_layer`] instead.
-    #[deprecated = "Use `transform_layer_shapes` instead"]
-    pub fn translate_layer(&self, layer_id: LayerId, delta: Vec2) {
-        if delta != Vec2::ZERO {
-            let transform = emath::TSTransform::from_translation(delta);
-            self.transform_layer_shapes(layer_id, transform);
-        }
+    let pointer_pos = self.input(|i| i.pointer.interact_pos());
+    let Some(pointer_pos) = pointer_pos else {
+      return false;
+    };
+
+    if !rect.contains(pointer_pos) {
+      return false;
     }
 
-    /// Transform all the graphics at the given layer.
-    ///
-    /// Is used to implement drag-and-drop preview.
-    ///
-    /// This only applied to the existing graphics at the layer, not to new graphics added later.
-    ///
-    /// For a persistent transform, use [`Self::set_transform_layer`] instead.
-    pub fn transform_layer_shapes(&self, layer_id: LayerId, transform: TSTransform) {
-        if transform != TSTransform::IDENTITY {
-            self.graphics_mut(|g| g.entry(layer_id).transform(transform));
-        }
+    if self.layer_id_at(pointer_pos) != Some(layer_id) {
+      return false;
     }
 
-    /// Top-most layer at the given position.
-    pub fn layer_id_at(&self, pos: Pos2) -> Option<LayerId> {
-        self.memory(|mem| mem.layer_id_at(pos))
-    }
+    true
+  }
 
-    /// Moves the given area to the top in its [`Order`].
-    ///
-    /// [`Area`]:s and [`Window`]:s also do this automatically when being clicked on or interacted with.
-    pub fn move_to_top(&self, layer_id: LayerId) {
-        self.memory_mut(|mem| mem.areas_mut().move_to_top(layer_id));
-    }
+  // ---------------------------------------------------------------------
 
-    /// Mark the `child` layer as a sublayer of `parent`.
-    ///
-    /// Sublayers are moved directly above the parent layer at the end of the frame. This is mainly
-    /// intended for adding a new [`Area`] inside a [`Window`].
-    ///
-    /// This currently only supports one level of nesting. If `parent` is a sublayer of another
-    /// layer, the behavior is unspecified.
-    pub fn set_sublayer(&self, parent: LayerId, child: LayerId) {
-        self.memory_mut(|mem| mem.areas_mut().set_sublayer(parent, child));
-    }
+  /// Whether or not to debug widget layout on hover.
+  #[cfg(debug_assertions)]
+  pub fn debug_on_hover(&self) -> bool {
+    self.options(|opt| opt.style.debug.debug_on_hover)
+  }
 
-    /// Retrieve the [`LayerId`] of the top level windows.
-    pub fn top_layer_id(&self) -> Option<LayerId> {
-        self.memory(|mem| mem.areas().top_layer_id(Order::Middle))
-    }
-
-    /// Does the given rectangle contain the mouse pointer?
-    ///
-    /// Will return false if some other area is covering the given layer.
-    ///
-    /// The given rectangle is assumed to have been clipped by its parent clip rect.
-    ///
-    /// See also [`Response::contains_pointer`].
-    pub fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
-        let rect =
-            if let Some(transform) = self.memory(|m| m.layer_transforms.get(&layer_id).copied()) {
-                transform * rect
-            } else {
-                rect
-            };
-        if !rect.is_positive() {
-            return false;
-        }
-
-        let pointer_pos = self.input(|i| i.pointer.interact_pos());
-        let Some(pointer_pos) = pointer_pos else {
-            return false;
-        };
-
-        if !rect.contains(pointer_pos) {
-            return false;
-        }
-
-        if self.layer_id_at(pointer_pos) != Some(layer_id) {
-            return false;
-        }
-
-        true
-    }
-
-    // ---------------------------------------------------------------------
-
-    /// Whether or not to debug widget layout on hover.
-    #[cfg(debug_assertions)]
-    pub fn debug_on_hover(&self) -> bool {
-        self.options(|opt| opt.style.debug.debug_on_hover)
-    }
-
-    /// Turn on/off whether or not to debug widget layout on hover.
-    #[cfg(debug_assertions)]
-    pub fn set_debug_on_hover(&self, debug_on_hover: bool) {
-        self.style_mut(|style| style.debug.debug_on_hover = debug_on_hover);
-    }
+  /// Turn on/off whether or not to debug widget layout on hover.
+  #[cfg(debug_assertions)]
+  pub fn set_debug_on_hover(&self, debug_on_hover: bool) {
+    self.style_mut(|style| style.debug.debug_on_hover = debug_on_hover);
+  }
 }
 
 /// ## Animation
 impl Context {
-    /// Returns a value in the range [0, 1], to indicate "how on" this thing is.
-    ///
-    /// The first time called it will return `if value { 1.0 } else { 0.0 }`
-    /// Calling this with `value = true` will always yield a number larger than zero, quickly going towards one.
-    /// Calling this with `value = false` will always yield a number less than one, quickly going towards zero.
-    ///
-    /// The function will call [`Self::request_repaint()`] when appropriate.
-    ///
-    /// The animation time is taken from [`Style::animation_time`].
-    #[track_caller] // To track repaint cause
-    pub fn animate_bool(&self, id: Id, value: bool) -> f32 {
-        let animation_time = self.style().animation_time;
-        self.animate_bool_with_time_and_easing(id, value, animation_time, emath::easing::linear)
+  /// Returns a value in the range [0, 1], to indicate "how on" this thing is.
+  ///
+  /// The first time called it will return `if value { 1.0 } else { 0.0 }`
+  /// Calling this with `value = true` will always yield a number larger than zero, quickly going towards one.
+  /// Calling this with `value = false` will always yield a number less than one, quickly going towards zero.
+  ///
+  /// The function will call [`Self::request_repaint()`] when appropriate.
+  ///
+  /// The animation time is taken from [`Style::animation_time`].
+  #[track_caller] // To track repaint cause
+  pub fn animate_bool(&self, id: Id, value: bool) -> f32 {
+    let animation_time = self.style().animation_time;
+    self.animate_bool_with_time_and_easing(id, value, animation_time, emath::easing::linear)
+  }
+
+  /// Like [`Self::animate_bool`], but uses an easing function that makes the value move
+  /// quickly in the beginning and slow down towards the end.
+  ///
+  /// The exact easing function may come to change in future versions of egui.
+  #[track_caller] // To track repaint cause
+  pub fn animate_bool_responsive(&self, id: Id, value: bool) -> f32 {
+    self.animate_bool_with_easing(id, value, emath::easing::cubic_out)
+  }
+
+  /// Like [`Self::animate_bool`] but allows you to control the easing function.
+  #[track_caller] // To track repaint cause
+  pub fn animate_bool_with_easing(&self, id: Id, value: bool, easing: fn(f32) -> f32) -> f32 {
+    let animation_time = self.style().animation_time;
+    self.animate_bool_with_time_and_easing(id, value, animation_time, easing)
+  }
+
+  /// Like [`Self::animate_bool`] but allows you to control the animation time.
+  #[track_caller] // To track repaint cause
+  pub fn animate_bool_with_time(&self, id: Id, target_value: bool, animation_time: f32) -> f32 {
+    self.animate_bool_with_time_and_easing(id, target_value, animation_time, emath::easing::linear)
+  }
+
+  /// Like [`Self::animate_bool`] but allows you to control the animation time and easing function.
+  ///
+  /// Use e.g. [`emath::easing::quadratic_out`]
+  /// for a responsive start and a slow end.
+  ///
+  /// The easing function flips when `target_value` is `false`,
+  /// so that when going back towards 0.0, we get
+  #[track_caller] // To track repaint cause
+  pub fn animate_bool_with_time_and_easing(
+    &self,
+    id: Id,
+    target_value: bool,
+    animation_time: f32,
+    easing: fn(f32) -> f32,
+  ) -> f32 {
+    let animated_value = self.write(|ctx| {
+      ctx.animation_manager.animate_bool(
+        &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
+        animation_time,
+        id,
+        target_value,
+      )
+    });
+
+    let animation_in_progress = 0.0 < animated_value && animated_value < 1.0;
+    if animation_in_progress {
+      self.request_repaint();
     }
 
-    /// Like [`Self::animate_bool`], but uses an easing function that makes the value move
-    /// quickly in the beginning and slow down towards the end.
-    ///
-    /// The exact easing function may come to change in future versions of egui.
-    #[track_caller] // To track repaint cause
-    pub fn animate_bool_responsive(&self, id: Id, value: bool) -> f32 {
-        self.animate_bool_with_easing(id, value, emath::easing::cubic_out)
+    if target_value {
+      easing(animated_value)
+    } else {
+      1.0 - easing(1.0 - animated_value)
+    }
+  }
+
+  /// Smoothly animate an `f32` value.
+  ///
+  /// At the first call the value is written to memory.
+  /// When it is called with a new value, it linearly interpolates to it in the given time.
+  #[track_caller] // To track repaint cause
+  pub fn animate_value_with_time(&self, id: Id, target_value: f32, animation_time: f32) -> f32 {
+    let animated_value = self.write(|ctx| {
+      ctx.animation_manager.animate_value(
+        &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
+        animation_time,
+        id,
+        target_value,
+      )
+    });
+    let animation_in_progress = animated_value != target_value;
+    if animation_in_progress {
+      self.request_repaint();
     }
 
-    /// Like [`Self::animate_bool`] but allows you to control the easing function.
-    #[track_caller] // To track repaint cause
-    pub fn animate_bool_with_easing(&self, id: Id, value: bool, easing: fn(f32) -> f32) -> f32 {
-        let animation_time = self.style().animation_time;
-        self.animate_bool_with_time_and_easing(id, value, animation_time, easing)
-    }
+    animated_value
+  }
 
-    /// Like [`Self::animate_bool`] but allows you to control the animation time.
-    #[track_caller] // To track repaint cause
-    pub fn animate_bool_with_time(&self, id: Id, target_value: bool, animation_time: f32) -> f32 {
-        self.animate_bool_with_time_and_easing(
-            id,
-            target_value,
-            animation_time,
-            emath::easing::linear,
-        )
-    }
-
-    /// Like [`Self::animate_bool`] but allows you to control the animation time and easing function.
-    ///
-    /// Use e.g. [`emath::easing::quadratic_out`]
-    /// for a responsive start and a slow end.
-    ///
-    /// The easing function flips when `target_value` is `false`,
-    /// so that when going back towards 0.0, we get
-    #[track_caller] // To track repaint cause
-    pub fn animate_bool_with_time_and_easing(
-        &self,
-        id: Id,
-        target_value: bool,
-        animation_time: f32,
-        easing: fn(f32) -> f32,
-    ) -> f32 {
-        let animated_value = self.write(|ctx| {
-            ctx.animation_manager.animate_bool(
-                &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
-                animation_time,
-                id,
-                target_value,
-            )
-        });
-
-        let animation_in_progress = 0.0 < animated_value && animated_value < 1.0;
-        if animation_in_progress {
-            self.request_repaint();
-        }
-
-        if target_value {
-            easing(animated_value)
-        } else {
-            1.0 - easing(1.0 - animated_value)
-        }
-    }
-
-    /// Smoothly animate an `f32` value.
-    ///
-    /// At the first call the value is written to memory.
-    /// When it is called with a new value, it linearly interpolates to it in the given time.
-    #[track_caller] // To track repaint cause
-    pub fn animate_value_with_time(&self, id: Id, target_value: f32, animation_time: f32) -> f32 {
-        let animated_value = self.write(|ctx| {
-            ctx.animation_manager.animate_value(
-                &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
-                animation_time,
-                id,
-                target_value,
-            )
-        });
-        let animation_in_progress = animated_value != target_value;
-        if animation_in_progress {
-            self.request_repaint();
-        }
-
-        animated_value
-    }
-
-    /// Clear memory of any animations.
-    pub fn clear_animations(&self) {
-        self.write(|ctx| ctx.animation_manager = Default::default());
-    }
+  /// Clear memory of any animations.
+  pub fn clear_animations(&self) {
+    self.write(|ctx| ctx.animation_manager = Default::default());
+  }
 }
 
 impl Context {
-    /// Show a ui for settings (style and tessellation options).
-    pub fn settings_ui(&self, ui: &mut Ui) {
-        let prev_options = self.options(|o| o.clone());
-        let mut options = prev_options.clone();
+  /// Show a ui for settings (style and tessellation options).
+  pub fn settings_ui(&self, ui: &mut Ui) {
+    let prev_options = self.options(|o| o.clone());
+    let mut options = prev_options.clone();
 
-        options.ui(ui);
+    options.ui(ui);
 
-        if options != prev_options {
-            self.options_mut(move |o| *o = options);
-        }
+    if options != prev_options {
+      self.options_mut(move |o| *o = options);
     }
+  }
 
-    /// Show the state of egui, including its input and output.
-    pub fn inspection_ui(&self, ui: &mut Ui) {
-        use crate::containers::*;
+  /// Show the state of egui, including its input and output.
+  pub fn inspection_ui(&self, ui: &mut Ui) {
+    use crate::containers::*;
 
-        ui.label(format!("Is using pointer: {}", self.is_using_pointer()))
-            .on_hover_text(
-                "Is egui currently using the pointer actively (e.g. dragging a slider)?",
-            );
-        ui.label(format!("Wants pointer input: {}", self.wants_pointer_input()))
+    ui.label(format!("Is using pointer: {}", self.is_using_pointer()))
+      .on_hover_text("Is egui currently using the pointer actively (e.g. dragging a slider)?");
+    ui.label(format!("Wants pointer input: {}", self.wants_pointer_input()))
             .on_hover_text("Is egui currently interested in the location of the pointer (either because it is in use, or because it is hovering over a window).");
-        ui.label(format!(
-            "Wants keyboard input: {}",
-            self.wants_keyboard_input()
-        ))
-        .on_hover_text("Is egui currently listening for text input?");
-        ui.label(format!(
-            "Keyboard focus widget: {}",
-            self.memory(|m| m.focused())
-                .as_ref()
-                .map(Id::short_debug_format)
-                .unwrap_or_default()
-        ))
-        .on_hover_text("Is egui currently listening for text input?");
+    ui.label(format!("Wants keyboard input: {}", self.wants_keyboard_input()))
+      .on_hover_text("Is egui currently listening for text input?");
+    ui.label(format!(
+      "Keyboard focus widget: {}",
+      self.memory(|m| m.focused()).as_ref().map(Id::short_debug_format).unwrap_or_default()
+    ))
+    .on_hover_text("Is egui currently listening for text input?");
 
-        let pointer_pos = self
-            .pointer_hover_pos()
-            .map_or_else(String::new, |pos| format!("{pos:?}"));
-        ui.label(format!("Pointer pos: {pointer_pos}"));
+    let pointer_pos = self.pointer_hover_pos().map_or_else(String::new, |pos| format!("{pos:?}"));
+    ui.label(format!("Pointer pos: {pointer_pos}"));
 
-        let top_layer = self
-            .pointer_hover_pos()
-            .and_then(|pos| self.layer_id_at(pos))
-            .map_or_else(String::new, |layer| layer.short_debug_format());
-        ui.label(format!("Top layer under mouse: {top_layer}"));
+    let top_layer = self
+      .pointer_hover_pos()
+      .and_then(|pos| self.layer_id_at(pos))
+      .map_or_else(String::new, |layer| layer.short_debug_format());
+    ui.label(format!("Top layer under mouse: {top_layer}"));
 
-        ui.add_space(16.0);
+    ui.add_space(16.0);
 
-        ui.label(format!(
-            "There are {} text galleys in the layout cache",
-            self.fonts(|f| f.num_galleys_in_cache())
-        ))
-        .on_hover_text("This is approximately the number of text strings on screen");
-        ui.add_space(16.0);
+    ui.label(format!("There are {} text galleys in the layout cache", self.fonts(|f| f.num_galleys_in_cache())))
+      .on_hover_text("This is approximately the number of text strings on screen");
+    ui.add_space(16.0);
 
-        CollapsingHeader::new("🔃 Repaint Causes")
-            .default_open(false)
-            .show(ui, |ui| {
-                ui.set_min_height(120.0);
-                ui.label("What caused egui to repaint:");
-                ui.add_space(8.0);
-                let causes = ui.ctx().repaint_causes();
-                for cause in causes {
-                    ui.label(cause.to_string());
-                }
-            });
+    CollapsingHeader::new("🔃 Repaint Causes").default_open(false).show(ui, |ui| {
+      ui.set_min_height(120.0);
+      ui.label("What caused egui to repaint:");
+      ui.add_space(8.0);
+      let causes = ui.ctx().repaint_causes();
+      for cause in causes {
+        ui.label(cause.to_string());
+      }
+    });
 
-        CollapsingHeader::new("📥 Input")
-            .default_open(false)
-            .show(ui, |ui| {
-                let input = ui.input(|i| i.clone());
-                input.ui(ui);
-            });
+    CollapsingHeader::new("📥 Input").default_open(false).show(ui, |ui| {
+      let input = ui.input(|i| i.clone());
+      input.ui(ui);
+    });
 
-        CollapsingHeader::new("📊 Paint stats")
-            .default_open(false)
-            .show(ui, |ui| {
-                let paint_stats = self.read(|ctx| ctx.paint_stats);
-                paint_stats.ui(ui);
-            });
+    CollapsingHeader::new("📊 Paint stats").default_open(false).show(ui, |ui| {
+      let paint_stats = self.read(|ctx| ctx.paint_stats);
+      paint_stats.ui(ui);
+    });
 
-        CollapsingHeader::new("🖼 Textures")
-            .default_open(false)
-            .show(ui, |ui| {
-                self.texture_ui(ui);
-            });
+    CollapsingHeader::new("🖼 Textures").default_open(false).show(ui, |ui| {
+      self.texture_ui(ui);
+    });
 
-        CollapsingHeader::new("🔠 Font texture")
-            .default_open(false)
-            .show(ui, |ui| {
-                let font_image_size = self.fonts(|f| f.font_image_size());
-                crate::introspection::font_texture_ui(ui, font_image_size);
-            });
+    CollapsingHeader::new("🔠 Font texture").default_open(false).show(ui, |ui| {
+      let font_image_size = self.fonts(|f| f.font_image_size());
+      crate::introspection::font_texture_ui(ui, font_image_size);
+    });
 
-        CollapsingHeader::new("Label text selection state")
-            .default_open(false)
-            .show(ui, |ui| {
-                ui.label(format!(
-                    "{:#?}",
-                    crate::text_selection::LabelSelectionState::load(ui.ctx())
-                ));
-            });
+    CollapsingHeader::new("Label text selection state").default_open(false).show(ui, |ui| {
+      ui.label(format!("{:#?}", crate::text_selection::LabelSelectionState::load(ui.ctx())));
+    });
 
-        CollapsingHeader::new("Interaction")
-            .default_open(false)
-            .show(ui, |ui| {
-                let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
-                interact_widgets.ui(ui);
-            });
+    CollapsingHeader::new("Interaction").default_open(false).show(ui, |ui| {
+      let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
+      interact_widgets.ui(ui);
+    });
+  }
+
+  /// Show stats about the allocated textures.
+  pub fn texture_ui(&self, ui: &mut crate::Ui) {
+    let tex_mngr = self.tex_manager();
+    let tex_mngr = tex_mngr.read();
+
+    let mut textures: Vec<_> = tex_mngr.allocated().collect();
+    textures.sort_by_key(|(id, _)| *id);
+
+    let mut bytes = 0;
+    for (_, tex) in &textures {
+      bytes += tex.bytes_used();
     }
 
-    /// Show stats about the allocated textures.
-    pub fn texture_ui(&self, ui: &mut crate::Ui) {
-        let tex_mngr = self.tex_manager();
-        let tex_mngr = tex_mngr.read();
+    ui.label(format!("{} allocated texture(s), using {:.1} MB", textures.len(), bytes as f64 * 1e-6));
+    let max_preview_size = vec2(48.0, 32.0);
 
-        let mut textures: Vec<_> = tex_mngr.allocated().collect();
-        textures.sort_by_key(|(id, _)| *id);
+    ui.group(|ui| {
+      ScrollArea::vertical().max_height(300.0).auto_shrink([false, true]).show(ui, |ui| {
+        ui.style_mut().override_text_style = Some(TextStyle::Monospace);
+        Grid::new("textures")
+          .striped(true)
+          .num_columns(4)
+          .spacing(vec2(16.0, 2.0))
+          .min_row_height(max_preview_size.y)
+          .show(ui, |ui| {
+            for (&texture_id, meta) in textures {
+              let [w, h] = meta.size;
 
-        let mut bytes = 0;
-        for (_, tex) in &textures {
-            bytes += tex.bytes_used();
+              let mut size = vec2(w as f32, h as f32);
+              size *= (max_preview_size.x / size.x).min(1.0);
+              size *= (max_preview_size.y / size.y).min(1.0);
+              ui.image(SizedTexture::new(texture_id, size)).on_hover_ui(|ui| {
+                // show larger on hover
+                let max_size = 0.5 * ui.ctx().screen_rect().size();
+                let mut size = vec2(w as f32, h as f32);
+                size *= max_size.x / size.x.max(max_size.x);
+                size *= max_size.y / size.y.max(max_size.y);
+                ui.image(SizedTexture::new(texture_id, size));
+              });
+
+              ui.label(format!("{w} x {h}"));
+              ui.label(format!("{:.3} MB", meta.bytes_used() as f64 * 1e-6));
+              ui.label(format!("{:?}", meta.name));
+              ui.end_row();
+            }
+          });
+      });
+    });
+  }
+
+  /// Shows the contents of [`Self::memory`].
+  pub fn memory_ui(&self, ui: &mut crate::Ui) {
+    if ui.button("Reset all").on_hover_text("Reset all egui state").clicked() {
+      self.memory_mut(|mem| *mem = Default::default());
+    }
+
+    let (num_state, num_serialized) = self.data(|d| (d.len(), d.count_serialized()));
+    ui.label(format!("{num_state} widget states stored (of which {num_serialized} are serialized)."));
+
+    ui.horizontal(|ui| {
+      ui.label(format!("{} areas (panels, windows, popups, …)", self.memory(|mem| mem.areas().count())));
+      if ui.button("Reset").clicked() {
+        self.memory_mut(|mem| *mem.areas_mut() = Default::default());
+      }
+    });
+    ui.indent("areas", |ui| {
+      ui.label("Visible areas, ordered back to front.");
+      ui.label("Hover to highlight");
+      let layers_ids: Vec<LayerId> = self.memory(|mem| mem.areas().order().to_vec());
+      for layer_id in layers_ids {
+        let area = AreaState::load(self, layer_id.id);
+        if let Some(area) = area {
+          let is_visible = self.memory(|mem| mem.areas().is_visible(&layer_id));
+          if !is_visible {
+            continue;
+          }
+          let text = format!("{} - {:?}", layer_id.short_debug_format(), area.rect(),);
+          // TODO(emilk): `Sense::hover_highlight()`
+          if ui.add(Label::new(RichText::new(text).monospace()).sense(Sense::click())).hovered && is_visible {
+            ui.ctx().debug_painter().debug_rect(area.rect(), Color32::RED, "");
+          }
         }
+      }
+    });
 
-        ui.label(format!(
-            "{} allocated texture(s), using {:.1} MB",
-            textures.len(),
-            bytes as f64 * 1e-6
-        ));
-        let max_preview_size = vec2(48.0, 32.0);
+    ui.horizontal(|ui| {
+      ui.label(format!("{} collapsing headers", self.data(|d| d.count::<containers::collapsing_header::InnerState>())));
+      if ui.button("Reset").clicked() {
+        self.data_mut(|d| d.remove_by_type::<containers::collapsing_header::InnerState>());
+      }
+    });
 
-        ui.group(|ui| {
-            ScrollArea::vertical()
-                .max_height(300.0)
-                .auto_shrink([false, true])
-                .show(ui, |ui| {
-                    ui.style_mut().override_text_style = Some(TextStyle::Monospace);
-                    Grid::new("textures")
-                        .striped(true)
-                        .num_columns(4)
-                        .spacing(vec2(16.0, 2.0))
-                        .min_row_height(max_preview_size.y)
-                        .show(ui, |ui| {
-                            for (&texture_id, meta) in textures {
-                                let [w, h] = meta.size;
+    ui.horizontal(|ui| {
+      ui.label(format!("{} menu bars", self.data(|d| d.count::<menu::BarState>())));
+      if ui.button("Reset").clicked() {
+        self.data_mut(|d| d.remove_by_type::<menu::BarState>());
+      }
+    });
 
-                                let mut size = vec2(w as f32, h as f32);
-                                size *= (max_preview_size.x / size.x).min(1.0);
-                                size *= (max_preview_size.y / size.y).min(1.0);
-                                ui.image(SizedTexture::new(texture_id, size))
-                                    .on_hover_ui(|ui| {
-                                        // show larger on hover
-                                        let max_size = 0.5 * ui.ctx().screen_rect().size();
-                                        let mut size = vec2(w as f32, h as f32);
-                                        size *= max_size.x / size.x.max(max_size.x);
-                                        size *= max_size.y / size.y.max(max_size.y);
-                                        ui.image(SizedTexture::new(texture_id, size));
-                                    });
+    ui.horizontal(|ui| {
+      ui.label(format!("{} scroll areas", self.data(|d| d.count::<scroll_area::State>())));
+      if ui.button("Reset").clicked() {
+        self.data_mut(|d| d.remove_by_type::<scroll_area::State>());
+      }
+    });
 
-                                ui.label(format!("{w} x {h}"));
-                                ui.label(format!("{:.3} MB", meta.bytes_used() as f64 * 1e-6));
-                                ui.label(format!("{:?}", meta.name));
-                                ui.end_row();
-                            }
-                        });
-                });
-        });
-    }
+    ui.horizontal(|ui| {
+      ui.label(format!("{} resize areas", self.data(|d| d.count::<resize::State>())));
+      if ui.button("Reset").clicked() {
+        self.data_mut(|d| d.remove_by_type::<resize::State>());
+      }
+    });
 
-    /// Shows the contents of [`Self::memory`].
-    pub fn memory_ui(&self, ui: &mut crate::Ui) {
-        if ui
-            .button("Reset all")
-            .on_hover_text("Reset all egui state")
-            .clicked()
-        {
-            self.memory_mut(|mem| *mem = Default::default());
-        }
+    ui.shrink_width_to_current(); // don't let the text below grow this window wider
+    ui.label("NOTE: the position of this window cannot be reset from within itself.");
 
-        let (num_state, num_serialized) = self.data(|d| (d.len(), d.count_serialized()));
-        ui.label(format!(
-            "{num_state} widget states stored (of which {num_serialized} are serialized)."
-        ));
-
-        ui.horizontal(|ui| {
-            ui.label(format!(
-                "{} areas (panels, windows, popups, …)",
-                self.memory(|mem| mem.areas().count())
-            ));
-            if ui.button("Reset").clicked() {
-                self.memory_mut(|mem| *mem.areas_mut() = Default::default());
-            }
-        });
-        ui.indent("areas", |ui| {
-            ui.label("Visible areas, ordered back to front.");
-            ui.label("Hover to highlight");
-            let layers_ids: Vec<LayerId> = self.memory(|mem| mem.areas().order().to_vec());
-            for layer_id in layers_ids {
-                let area = AreaState::load(self, layer_id.id);
-                if let Some(area) = area {
-                    let is_visible = self.memory(|mem| mem.areas().is_visible(&layer_id));
-                    if !is_visible {
-                        continue;
-                    }
-                    let text = format!("{} - {:?}", layer_id.short_debug_format(), area.rect(),);
-                    // TODO(emilk): `Sense::hover_highlight()`
-                    if ui
-                        .add(Label::new(RichText::new(text).monospace()).sense(Sense::click()))
-                        .hovered
-                        && is_visible
-                    {
-                        ui.ctx()
-                            .debug_painter()
-                            .debug_rect(area.rect(), Color32::RED, "");
-                    }
-                }
-            }
-        });
-
-        ui.horizontal(|ui| {
-            ui.label(format!(
-                "{} collapsing headers",
-                self.data(|d| d.count::<containers::collapsing_header::InnerState>())
-            ));
-            if ui.button("Reset").clicked() {
-                self.data_mut(|d| d.remove_by_type::<containers::collapsing_header::InnerState>());
-            }
-        });
-
-        ui.horizontal(|ui| {
-            ui.label(format!(
-                "{} menu bars",
-                self.data(|d| d.count::<menu::BarState>())
-            ));
-            if ui.button("Reset").clicked() {
-                self.data_mut(|d| d.remove_by_type::<menu::BarState>());
-            }
-        });
-
-        ui.horizontal(|ui| {
-            ui.label(format!(
-                "{} scroll areas",
-                self.data(|d| d.count::<scroll_area::State>())
-            ));
-            if ui.button("Reset").clicked() {
-                self.data_mut(|d| d.remove_by_type::<scroll_area::State>());
-            }
-        });
-
-        ui.horizontal(|ui| {
-            ui.label(format!(
-                "{} resize areas",
-                self.data(|d| d.count::<resize::State>())
-            ));
-            if ui.button("Reset").clicked() {
-                self.data_mut(|d| d.remove_by_type::<resize::State>());
-            }
-        });
-
-        ui.shrink_width_to_current(); // don't let the text below grow this window wider
-        ui.label("NOTE: the position of this window cannot be reset from within itself.");
-
-        ui.collapsing("Interaction", |ui| {
-            let interaction = self.memory(|mem| mem.interaction().clone());
-            interaction.ui(ui);
-        });
-    }
+    ui.collapsing("Interaction", |ui| {
+      let interaction = self.memory(|mem| mem.interaction().clone());
+      interaction.ui(ui);
+    });
+  }
 }
 
 impl Context {
-    /// Edit the active [`Style`].
-    pub fn style_ui(&self, ui: &mut Ui) {
-        let mut style: Style = (*self.style()).clone();
-        style.ui(ui);
-        self.set_style(style);
-    }
+  /// Edit the active [`Style`].
+  pub fn style_ui(&self, ui: &mut Ui) {
+    let mut style: Style = (*self.style()).clone();
+    style.ui(ui);
+    self.set_style(style);
+  }
 }
 
 /// ## Accessibility
 impl Context {
-    /// Call the provided function with the given ID pushed on the stack of
-    /// parent IDs for accessibility purposes. If the `accesskit` feature
-    /// is disabled or if AccessKit support is not active for this frame,
-    /// the function is still called, but with no other effect.
-    ///
-    /// No locks are held while the given closure is called.
-    #[allow(clippy::unused_self)]
-    #[inline]
-    pub fn with_accessibility_parent(&self, _id: Id, f: impl FnOnce()) {
-        // TODO(emilk): this isn't thread-safe - another thread can call this function between the push/pop calls
-        #[cfg(feature = "accesskit")]
-        self.frame_state_mut(|fs| {
-            if let Some(state) = fs.accesskit_state.as_mut() {
-                state.parent_stack.push(_id);
-            }
-        });
-
-        f();
-
-        #[cfg(feature = "accesskit")]
-        self.frame_state_mut(|fs| {
-            if let Some(state) = fs.accesskit_state.as_mut() {
-                assert_eq!(state.parent_stack.pop(), Some(_id));
-            }
-        });
-    }
-
-    /// If AccessKit support is active for the current frame, get or create
-    /// a node builder with the specified ID and return a mutable reference to it.
-    /// For newly created nodes, the parent is the node with the ID at the top
-    /// of the stack managed by [`Context::with_accessibility_parent`].
-    ///
-    /// The `Context` lock is held while the given closure is called!
-    ///
-    /// Returns `None` if acesskit is off.
-    // TODO(emilk): consider making both read-only and read-write versions
+  /// Call the provided function with the given ID pushed on the stack of
+  /// parent IDs for accessibility purposes. If the `accesskit` feature
+  /// is disabled or if AccessKit support is not active for this frame,
+  /// the function is still called, but with no other effect.
+  ///
+  /// No locks are held while the given closure is called.
+  #[allow(clippy::unused_self)]
+  #[inline]
+  pub fn with_accessibility_parent(&self, _id: Id, f: impl FnOnce()) {
+    // TODO(emilk): this isn't thread-safe - another thread can call this function between the push/pop calls
     #[cfg(feature = "accesskit")]
-    pub fn accesskit_node_builder<R>(
-        &self,
-        id: Id,
-        writer: impl FnOnce(&mut accesskit::NodeBuilder) -> R,
-    ) -> Option<R> {
-        self.write(|ctx| {
-            ctx.viewport()
-                .this_frame
-                .accesskit_state
-                .is_some()
-                .then(|| ctx.accesskit_node_builder(id))
-                .map(writer)
-        })
-    }
+    self.frame_state_mut(|fs| {
+      if let Some(state) = fs.accesskit_state.as_mut() {
+        state.parent_stack.push(_id);
+      }
+    });
 
-    /// Enable generation of AccessKit tree updates in all future frames.
-    ///
-    /// If it's practical for the egui integration to immediately run the egui
-    /// application when it is either initializing the AccessKit adapter or
-    /// being called by the AccessKit adapter to provide the initial tree update,
-    /// then it should do so, to provide a complete AccessKit tree to the adapter
-    /// immediately. Otherwise, it should enqueue a repaint and use the
-    /// placeholder tree update from [`Context::accesskit_placeholder_tree_update`]
-    /// in the meantime.
+    f();
+
     #[cfg(feature = "accesskit")]
-    pub fn enable_accesskit(&self) {
-        self.write(|ctx| ctx.is_accesskit_enabled = true);
-    }
+    self.frame_state_mut(|fs| {
+      if let Some(state) = fs.accesskit_state.as_mut() {
+        assert_eq!(state.parent_stack.pop(), Some(_id));
+      }
+    });
+  }
 
-    /// Return a tree update that the egui integration should provide to the
-    /// AccessKit adapter if it cannot immediately run the egui application
-    /// to get a full tree update after running [`Context::enable_accesskit`].
-    #[cfg(feature = "accesskit")]
-    pub fn accesskit_placeholder_tree_update(&self) -> accesskit::TreeUpdate {
-        crate::profile_function!();
+  /// If AccessKit support is active for the current frame, get or create
+  /// a node builder with the specified ID and return a mutable reference to it.
+  /// For newly created nodes, the parent is the node with the ID at the top
+  /// of the stack managed by [`Context::with_accessibility_parent`].
+  ///
+  /// The `Context` lock is held while the given closure is called!
+  ///
+  /// Returns `None` if acesskit is off.
+  // TODO(emilk): consider making both read-only and read-write versions
+  #[cfg(feature = "accesskit")]
+  pub fn accesskit_node_builder<R>(&self, id: Id, writer: impl FnOnce(&mut accesskit::NodeBuilder) -> R) -> Option<R> {
+    self.write(|ctx| {
+      ctx.viewport().this_frame.accesskit_state.is_some().then(|| ctx.accesskit_node_builder(id)).map(writer)
+    })
+  }
 
-        use accesskit::{NodeBuilder, Role, Tree, TreeUpdate};
+  /// Enable generation of AccessKit tree updates in all future frames.
+  ///
+  /// If it's practical for the egui integration to immediately run the egui
+  /// application when it is either initializing the AccessKit adapter or
+  /// being called by the AccessKit adapter to provide the initial tree update,
+  /// then it should do so, to provide a complete AccessKit tree to the adapter
+  /// immediately. Otherwise, it should enqueue a repaint and use the
+  /// placeholder tree update from [`Context::accesskit_placeholder_tree_update`]
+  /// in the meantime.
+  #[cfg(feature = "accesskit")]
+  pub fn enable_accesskit(&self) {
+    self.write(|ctx| ctx.is_accesskit_enabled = true);
+  }
 
-        let root_id = crate::accesskit_root_id().accesskit_id();
-        self.write(|ctx| TreeUpdate {
-            nodes: vec![(
-                root_id,
-                NodeBuilder::new(Role::Window).build(&mut ctx.accesskit_node_classes),
-            )],
-            tree: Some(Tree::new(root_id)),
-            focus: root_id,
-        })
-    }
+  /// Return a tree update that the egui integration should provide to the
+  /// AccessKit adapter if it cannot immediately run the egui application
+  /// to get a full tree update after running [`Context::enable_accesskit`].
+  #[cfg(feature = "accesskit")]
+  pub fn accesskit_placeholder_tree_update(&self) -> accesskit::TreeUpdate {
+    crate::profile_function!();
+
+    use accesskit::{NodeBuilder, Role, Tree, TreeUpdate};
+
+    let root_id = crate::accesskit_root_id().accesskit_id();
+    self.write(|ctx| TreeUpdate {
+      nodes: vec![(root_id, NodeBuilder::new(Role::Window).build(&mut ctx.accesskit_node_classes))],
+      tree: Some(Tree::new(root_id)),
+      focus: root_id,
+    })
+  }
 }
 
 /// ## Image loading
 impl Context {
-    /// Associate some static bytes with a `uri`.
-    ///
-    /// The same `uri` may be passed to [`Ui::image`] later to load the bytes as an image.
-    ///
-    /// By convention, the `uri` should start with `bytes://`.
-    /// Following that convention will lead to better error messages.
-    pub fn include_bytes(&self, uri: impl Into<Cow<'static, str>>, bytes: impl Into<Bytes>) {
-        self.loaders().include.insert(uri, bytes);
+  /// Associate some static bytes with a `uri`.
+  ///
+  /// The same `uri` may be passed to [`Ui::image`] later to load the bytes as an image.
+  ///
+  /// By convention, the `uri` should start with `bytes://`.
+  /// Following that convention will lead to better error messages.
+  pub fn include_bytes(&self, uri: impl Into<Cow<'static, str>>, bytes: impl Into<Bytes>) {
+    self.loaders().include.insert(uri, bytes);
+  }
+
+  /// Returns `true` if the chain of bytes, image, or texture loaders
+  /// contains a loader with the given `id`.
+  pub fn is_loader_installed(&self, id: &str) -> bool {
+    let loaders = self.loaders();
+
+    loaders.bytes.lock().iter().any(|l| l.id() == id)
+      || loaders.image.lock().iter().any(|l| l.id() == id)
+      || loaders.texture.lock().iter().any(|l| l.id() == id)
+  }
+
+  /// Add a new bytes loader.
+  ///
+  /// It will be tried first, before any already installed loaders.
+  ///
+  /// See [`load`] for more information.
+  pub fn add_bytes_loader(&self, loader: Arc<dyn load::BytesLoader + Send + Sync + 'static>) {
+    self.loaders().bytes.lock().push(loader);
+  }
+
+  /// Add a new image loader.
+  ///
+  /// It will be tried first, before any already installed loaders.
+  ///
+  /// See [`load`] for more information.
+  pub fn add_image_loader(&self, loader: Arc<dyn load::ImageLoader + Send + Sync + 'static>) {
+    self.loaders().image.lock().push(loader);
+  }
+
+  /// Add a new texture loader.
+  ///
+  /// It will be tried first, before any already installed loaders.
+  ///
+  /// See [`load`] for more information.
+  pub fn add_texture_loader(&self, loader: Arc<dyn load::TextureLoader + Send + Sync + 'static>) {
+    self.loaders().texture.lock().push(loader);
+  }
+
+  /// Release all memory and textures related to the given image URI.
+  ///
+  /// If you attempt to load the image again, it will be reloaded from scratch.
+  pub fn forget_image(&self, uri: &str) {
+    use load::BytesLoader as _;
+
+    crate::profile_function!();
+
+    let loaders = self.loaders();
+
+    loaders.include.forget(uri);
+    for loader in loaders.bytes.lock().iter() {
+      loader.forget(uri);
+    }
+    for loader in loaders.image.lock().iter() {
+      loader.forget(uri);
+    }
+    for loader in loaders.texture.lock().iter() {
+      loader.forget(uri);
+    }
+  }
+
+  /// Release all memory and textures related to images used in [`Ui::image`] or [`Image`].
+  ///
+  /// If you attempt to load any images again, they will be reloaded from scratch.
+  pub fn forget_all_images(&self) {
+    use load::BytesLoader as _;
+
+    crate::profile_function!();
+
+    let loaders = self.loaders();
+
+    loaders.include.forget_all();
+    for loader in loaders.bytes.lock().iter() {
+      loader.forget_all();
+    }
+    for loader in loaders.image.lock().iter() {
+      loader.forget_all();
+    }
+    for loader in loaders.texture.lock().iter() {
+      loader.forget_all();
+    }
+  }
+
+  /// Try loading the bytes from the given uri using any available bytes loaders.
+  ///
+  /// Loaders are expected to cache results, so that this call is immediate-mode safe.
+  ///
+  /// This calls the loaders one by one in the order in which they were registered.
+  /// If a loader returns [`LoadError::NotSupported`][not_supported],
+  /// then the next loader is called. This process repeats until all loaders have
+  /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
+  ///
+  /// # Errors
+  /// This may fail with:
+  /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
+  /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
+  ///
+  /// ⚠ May deadlock if called from within a `BytesLoader`!
+  ///
+  /// [not_supported]: crate::load::LoadError::NotSupported
+  /// [custom]: crate::load::LoadError::Loading
+  pub fn try_load_bytes(&self, uri: &str) -> load::BytesLoadResult {
+    crate::profile_function!(uri);
+
+    let loaders = self.loaders();
+    let bytes_loaders = loaders.bytes.lock();
+
+    // Try most recently added loaders first (hence `.rev()`)
+    for loader in bytes_loaders.iter().rev() {
+      match loader.load(self, uri) {
+        Err(load::LoadError::NotSupported) => continue,
+        result => return result,
+      }
     }
 
-    /// Returns `true` if the chain of bytes, image, or texture loaders
-    /// contains a loader with the given `id`.
-    pub fn is_loader_installed(&self, id: &str) -> bool {
-        let loaders = self.loaders();
+    Err(load::LoadError::NoMatchingBytesLoader)
+  }
 
-        loaders.bytes.lock().iter().any(|l| l.id() == id)
-            || loaders.image.lock().iter().any(|l| l.id() == id)
-            || loaders.texture.lock().iter().any(|l| l.id() == id)
+  /// Try loading the image from the given uri using any available image loaders.
+  ///
+  /// Loaders are expected to cache results, so that this call is immediate-mode safe.
+  ///
+  /// This calls the loaders one by one in the order in which they were registered.
+  /// If a loader returns [`LoadError::NotSupported`][not_supported],
+  /// then the next loader is called. This process repeats until all loaders have
+  /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
+  ///
+  /// # Errors
+  /// This may fail with:
+  /// - [`LoadError::NoImageLoaders`][no_image_loaders] if tbere are no registered image loaders.
+  /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
+  /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
+  ///
+  /// ⚠ May deadlock if called from within an `ImageLoader`!
+  ///
+  /// [no_image_loaders]: crate::load::LoadError::NoImageLoaders
+  /// [not_supported]: crate::load::LoadError::NotSupported
+  /// [custom]: crate::load::LoadError::Loading
+  pub fn try_load_image(&self, uri: &str, size_hint: load::SizeHint) -> load::ImageLoadResult {
+    crate::profile_function!(uri);
+
+    let loaders = self.loaders();
+    let image_loaders = loaders.image.lock();
+    if image_loaders.is_empty() {
+      return Err(load::LoadError::NoImageLoaders);
     }
 
-    /// Add a new bytes loader.
-    ///
-    /// It will be tried first, before any already installed loaders.
-    ///
-    /// See [`load`] for more information.
-    pub fn add_bytes_loader(&self, loader: Arc<dyn load::BytesLoader + Send + Sync + 'static>) {
-        self.loaders().bytes.lock().push(loader);
+    // Try most recently added loaders first (hence `.rev()`)
+    for loader in image_loaders.iter().rev() {
+      match loader.load(self, uri, size_hint) {
+        Err(load::LoadError::NotSupported) => continue,
+        result => return result,
+      }
     }
 
-    /// Add a new image loader.
-    ///
-    /// It will be tried first, before any already installed loaders.
-    ///
-    /// See [`load`] for more information.
-    pub fn add_image_loader(&self, loader: Arc<dyn load::ImageLoader + Send + Sync + 'static>) {
-        self.loaders().image.lock().push(loader);
+    Err(load::LoadError::NoMatchingImageLoader)
+  }
+
+  /// Try loading the texture from the given uri using any available texture loaders.
+  ///
+  /// Loaders are expected to cache results, so that this call is immediate-mode safe.
+  ///
+  /// This calls the loaders one by one in the order in which they were registered.
+  /// If a loader returns [`LoadError::NotSupported`][not_supported],
+  /// then the next loader is called. This process repeats until all loaders have
+  /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
+  ///
+  /// # Errors
+  /// This may fail with:
+  /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
+  /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
+  ///
+  /// ⚠ May deadlock if called from within a `TextureLoader`!
+  ///
+  /// [not_supported]: crate::load::LoadError::NotSupported
+  /// [custom]: crate::load::LoadError::Loading
+  pub fn try_load_texture(
+    &self,
+    uri: &str,
+    texture_options: TextureOptions,
+    size_hint: load::SizeHint,
+  ) -> load::TextureLoadResult {
+    crate::profile_function!(uri);
+
+    let loaders = self.loaders();
+    let texture_loaders = loaders.texture.lock();
+
+    // Try most recently added loaders first (hence `.rev()`)
+    for loader in texture_loaders.iter().rev() {
+      match loader.load(self, uri, texture_options, size_hint) {
+        Err(load::LoadError::NotSupported) => continue,
+        result => return result,
+      }
     }
 
-    /// Add a new texture loader.
-    ///
-    /// It will be tried first, before any already installed loaders.
-    ///
-    /// See [`load`] for more information.
-    pub fn add_texture_loader(&self, loader: Arc<dyn load::TextureLoader + Send + Sync + 'static>) {
-        self.loaders().texture.lock().push(loader);
-    }
+    Err(load::LoadError::NoMatchingTextureLoader)
+  }
 
-    /// Release all memory and textures related to the given image URI.
-    ///
-    /// If you attempt to load the image again, it will be reloaded from scratch.
-    pub fn forget_image(&self, uri: &str) {
-        use load::BytesLoader as _;
-
-        crate::profile_function!();
-
-        let loaders = self.loaders();
-
-        loaders.include.forget(uri);
-        for loader in loaders.bytes.lock().iter() {
-            loader.forget(uri);
-        }
-        for loader in loaders.image.lock().iter() {
-            loader.forget(uri);
-        }
-        for loader in loaders.texture.lock().iter() {
-            loader.forget(uri);
-        }
-    }
-
-    /// Release all memory and textures related to images used in [`Ui::image`] or [`Image`].
-    ///
-    /// If you attempt to load any images again, they will be reloaded from scratch.
-    pub fn forget_all_images(&self) {
-        use load::BytesLoader as _;
-
-        crate::profile_function!();
-
-        let loaders = self.loaders();
-
-        loaders.include.forget_all();
-        for loader in loaders.bytes.lock().iter() {
-            loader.forget_all();
-        }
-        for loader in loaders.image.lock().iter() {
-            loader.forget_all();
-        }
-        for loader in loaders.texture.lock().iter() {
-            loader.forget_all();
-        }
-    }
-
-    /// Try loading the bytes from the given uri using any available bytes loaders.
-    ///
-    /// Loaders are expected to cache results, so that this call is immediate-mode safe.
-    ///
-    /// This calls the loaders one by one in the order in which they were registered.
-    /// If a loader returns [`LoadError::NotSupported`][not_supported],
-    /// then the next loader is called. This process repeats until all loaders have
-    /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
-    ///
-    /// # Errors
-    /// This may fail with:
-    /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
-    /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
-    ///
-    /// ⚠ May deadlock if called from within a `BytesLoader`!
-    ///
-    /// [not_supported]: crate::load::LoadError::NotSupported
-    /// [custom]: crate::load::LoadError::Loading
-    pub fn try_load_bytes(&self, uri: &str) -> load::BytesLoadResult {
-        crate::profile_function!(uri);
-
-        let loaders = self.loaders();
-        let bytes_loaders = loaders.bytes.lock();
-
-        // Try most recently added loaders first (hence `.rev()`)
-        for loader in bytes_loaders.iter().rev() {
-            match loader.load(self, uri) {
-                Err(load::LoadError::NotSupported) => continue,
-                result => return result,
-            }
-        }
-
-        Err(load::LoadError::NoMatchingBytesLoader)
-    }
-
-    /// Try loading the image from the given uri using any available image loaders.
-    ///
-    /// Loaders are expected to cache results, so that this call is immediate-mode safe.
-    ///
-    /// This calls the loaders one by one in the order in which they were registered.
-    /// If a loader returns [`LoadError::NotSupported`][not_supported],
-    /// then the next loader is called. This process repeats until all loaders have
-    /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
-    ///
-    /// # Errors
-    /// This may fail with:
-    /// - [`LoadError::NoImageLoaders`][no_image_loaders] if tbere are no registered image loaders.
-    /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
-    /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
-    ///
-    /// ⚠ May deadlock if called from within an `ImageLoader`!
-    ///
-    /// [no_image_loaders]: crate::load::LoadError::NoImageLoaders
-    /// [not_supported]: crate::load::LoadError::NotSupported
-    /// [custom]: crate::load::LoadError::Loading
-    pub fn try_load_image(&self, uri: &str, size_hint: load::SizeHint) -> load::ImageLoadResult {
-        crate::profile_function!(uri);
-
-        let loaders = self.loaders();
-        let image_loaders = loaders.image.lock();
-        if image_loaders.is_empty() {
-            return Err(load::LoadError::NoImageLoaders);
-        }
-
-        // Try most recently added loaders first (hence `.rev()`)
-        for loader in image_loaders.iter().rev() {
-            match loader.load(self, uri, size_hint) {
-                Err(load::LoadError::NotSupported) => continue,
-                result => return result,
-            }
-        }
-
-        Err(load::LoadError::NoMatchingImageLoader)
-    }
-
-    /// Try loading the texture from the given uri using any available texture loaders.
-    ///
-    /// Loaders are expected to cache results, so that this call is immediate-mode safe.
-    ///
-    /// This calls the loaders one by one in the order in which they were registered.
-    /// If a loader returns [`LoadError::NotSupported`][not_supported],
-    /// then the next loader is called. This process repeats until all loaders have
-    /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
-    ///
-    /// # Errors
-    /// This may fail with:
-    /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
-    /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
-    ///
-    /// ⚠ May deadlock if called from within a `TextureLoader`!
-    ///
-    /// [not_supported]: crate::load::LoadError::NotSupported
-    /// [custom]: crate::load::LoadError::Loading
-    pub fn try_load_texture(
-        &self,
-        uri: &str,
-        texture_options: TextureOptions,
-        size_hint: load::SizeHint,
-    ) -> load::TextureLoadResult {
-        crate::profile_function!(uri);
-
-        let loaders = self.loaders();
-        let texture_loaders = loaders.texture.lock();
-
-        // Try most recently added loaders first (hence `.rev()`)
-        for loader in texture_loaders.iter().rev() {
-            match loader.load(self, uri, texture_options, size_hint) {
-                Err(load::LoadError::NotSupported) => continue,
-                result => return result,
-            }
-        }
-
-        Err(load::LoadError::NoMatchingTextureLoader)
-    }
-
-    /// The loaders of bytes, images, and textures.
-    pub fn loaders(&self) -> Arc<Loaders> {
-        crate::profile_function!();
-        self.read(|this| this.loaders.clone())
-    }
+  /// The loaders of bytes, images, and textures.
+  pub fn loaders(&self) -> Arc<Loaders> {
+    crate::profile_function!();
+    self.read(|this| this.loaders.clone())
+  }
 }
 
 /// ## Viewports
 impl Context {
-    /// Return the `ViewportId` of the current viewport.
-    ///
-    /// If this is the root viewport, this will return [`ViewportId::ROOT`].
-    ///
-    /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
-    pub fn viewport_id(&self) -> ViewportId {
-        self.read(|ctx| ctx.viewport_id())
+  /// Return the `ViewportId` of the current viewport.
+  ///
+  /// If this is the root viewport, this will return [`ViewportId::ROOT`].
+  ///
+  /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
+  pub fn viewport_id(&self) -> ViewportId {
+    self.read(|ctx| ctx.viewport_id())
+  }
+
+  /// Return the `ViewportId` of his parent.
+  ///
+  /// If this is the root viewport, this will return [`ViewportId::ROOT`].
+  ///
+  /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
+  pub fn parent_viewport_id(&self) -> ViewportId {
+    self.read(|ctx| ctx.parent_viewport_id())
+  }
+
+  /// Read the state of the current viewport.
+  pub fn viewport<R>(&self, reader: impl FnOnce(&ViewportState) -> R) -> R {
+    self.write(|ctx| reader(ctx.viewport()))
+  }
+
+  /// Read the state of a specific current viewport.
+  pub fn viewport_for<R>(&self, viewport_id: ViewportId, reader: impl FnOnce(&ViewportState) -> R) -> R {
+    self.write(|ctx| reader(ctx.viewport_for(viewport_id)))
+  }
+
+  /// For integrations: Set this to render a sync viewport.
+  ///
+  /// This will only set the callback for the current thread,
+  /// which most likely should be the main thread.
+  ///
+  /// When an immediate viewport is created with [`Self::show_viewport_immediate`] it will be rendered by this function.
+  ///
+  /// When called, the integration needs to:
+  /// * Check if there already is a window for this viewport id, and if not open one
+  /// * Set the window attributes (position, size, …) based on [`ImmediateViewport::builder`].
+  /// * Call [`Context::run`] with [`ImmediateViewport::viewport_ui_cb`].
+  /// * Handle the output from [`Context::run`], including rendering
+  #[allow(clippy::unused_self)]
+  pub fn set_immediate_viewport_renderer(callback: impl for<'a> Fn(&Self, ImmediateViewport<'a>) + 'static) {
+    let callback = Box::new(callback);
+    IMMEDIATE_VIEWPORT_RENDERER.with(|render_sync| {
+      render_sync.replace(Some(callback));
+    });
+  }
+
+  /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
+  /// embed the new viewports inside the existing one, instead of spawning a new native window.
+  ///
+  /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
+  pub fn embed_viewports(&self) -> bool {
+    self.read(|ctx| ctx.embed_viewports)
+  }
+
+  /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
+  /// embed the new viewports inside the existing one, instead of spawning a new native window.
+  ///
+  /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
+  pub fn set_embed_viewports(&self, value: bool) {
+    self.write(|ctx| ctx.embed_viewports = value);
+  }
+
+  /// Send a command to the current viewport.
+  ///
+  /// This lets you affect the current viewport, e.g. resizing the window.
+  pub fn send_viewport_cmd(&self, command: ViewportCommand) {
+    self.send_viewport_cmd_to(self.viewport_id(), command);
+  }
+
+  /// Send a command to a specific viewport.
+  ///
+  /// This lets you affect another viewport, e.g. resizing its window.
+  pub fn send_viewport_cmd_to(&self, id: ViewportId, command: ViewportCommand) {
+    self.request_repaint_of(id);
+
+    if command.requires_parent_repaint() {
+      self.request_repaint_of(self.parent_viewport_id());
     }
 
-    /// Return the `ViewportId` of his parent.
-    ///
-    /// If this is the root viewport, this will return [`ViewportId::ROOT`].
-    ///
-    /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
-    pub fn parent_viewport_id(&self) -> ViewportId {
-        self.read(|ctx| ctx.parent_viewport_id())
+    self.write(|ctx| ctx.viewport_for(id).commands.push(command));
+  }
+
+  /// Show a deferred viewport, creating a new native window, if possible.
+  ///
+  /// The given id must be unique for each viewport.
+  ///
+  /// You need to call this each frame when the child viewport should exist.
+  ///
+  /// You can check if the user wants to close the viewport by checking the
+  /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
+  ///
+  /// The given callback will be called whenever the child viewport needs repainting,
+  /// e.g. on an event or when [`Self::request_repaint`] is called.
+  /// This means it may be called multiple times, for instance while the
+  /// parent viewport (the caller) is sleeping but the child viewport is animating.
+  ///
+  /// You will need to wrap your viewport state in an `Arc<RwLock<T>>` or `Arc<Mutex<T>>`.
+  /// When this is called again with the same id in `ViewportBuilder` the render function for that viewport will be updated.
+  ///
+  /// You can also use [`Self::show_viewport_immediate`], which uses a simpler `FnOnce`
+  /// with no need for `Send` or `Sync`. The downside is that it will require
+  /// the parent viewport (the caller) to repaint anytime the child is repainted,
+  /// and vice versa.
+  ///
+  /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
+  /// backend does not support multiple viewports), the given callback
+  /// will be called immediately, embedding the new viewport in the current one.
+  /// You can check this with the [`ViewportClass`] given in the callback.
+  /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
+  ///
+  /// See [`crate::viewport`] for more information about viewports.
+  pub fn show_viewport_deferred(
+    &self,
+    new_viewport_id: ViewportId,
+    viewport_builder: ViewportBuilder,
+    viewport_ui_cb: impl Fn(&Self, ViewportClass) + Send + Sync + 'static,
+  ) {
+    crate::profile_function!();
+
+    if self.embed_viewports() {
+      viewport_ui_cb(self, ViewportClass::Embedded);
+    } else {
+      self.write(|ctx| {
+        ctx.viewport_parents.insert(new_viewport_id, ctx.viewport_id());
+
+        let viewport = ctx.viewports.entry(new_viewport_id).or_default();
+        viewport.class = ViewportClass::Deferred;
+        viewport.builder = viewport_builder;
+        viewport.used = true;
+        viewport.viewport_ui_cb = Some(Arc::new(move |ctx| {
+          (viewport_ui_cb)(ctx, ViewportClass::Deferred);
+        }));
+      });
+    }
+  }
+
+  /// Show an immediate viewport, creating a new native window, if possible.
+  ///
+  /// This is the easier type of viewport to use, but it is less performant
+  /// at it requires both parent and child to repaint if any one of them needs repainting,
+  /// which efficvely produce double work for two viewports, and triple work for three viewports, etc.
+  /// To avoid this, use [`Self::show_viewport_deferred`] instead.
+  ///
+  /// The given id must be unique for each viewport.
+  ///
+  /// You need to call this each frame when the child viewport should exist.
+  ///
+  /// You can check if the user wants to close the viewport by checking the
+  /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
+  ///
+  /// The given ui function will be called immediately.
+  /// This may only be called on the main thread.
+  /// This call will pause the current viewport and render the child viewport in its own window.
+  /// This means that the child viewport will not be repainted when the parent viewport is repainted, and vice versa.
+  ///
+  /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
+  /// backend does not support multiple viewports), the given callback
+  /// will be called immediately, embedding the new viewport in the current one.
+  /// You can check this with the [`ViewportClass`] given in the callback.
+  /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
+  ///
+  /// See [`crate::viewport`] for more information about viewports.
+  pub fn show_viewport_immediate<T>(
+    &self,
+    new_viewport_id: ViewportId,
+    builder: ViewportBuilder,
+    viewport_ui_cb: impl FnOnce(&Self, ViewportClass) -> T,
+  ) -> T {
+    crate::profile_function!();
+
+    if self.embed_viewports() {
+      return viewport_ui_cb(self, ViewportClass::Embedded);
     }
 
-    /// Read the state of the current viewport.
-    pub fn viewport<R>(&self, reader: impl FnOnce(&ViewportState) -> R) -> R {
-        self.write(|ctx| reader(ctx.viewport()))
-    }
+    IMMEDIATE_VIEWPORT_RENDERER.with(|immediate_viewport_renderer| {
+      let immediate_viewport_renderer = immediate_viewport_renderer.borrow();
+      let Some(immediate_viewport_renderer) = immediate_viewport_renderer.as_ref() else {
+        // This egui backend does not support multiple viewports.
+        return viewport_ui_cb(self, ViewportClass::Embedded);
+      };
 
-    /// Read the state of a specific current viewport.
-    pub fn viewport_for<R>(
-        &self,
-        viewport_id: ViewportId,
-        reader: impl FnOnce(&ViewportState) -> R,
-    ) -> R {
-        self.write(|ctx| reader(ctx.viewport_for(viewport_id)))
-    }
+      let ids = self.write(|ctx| {
+        let parent_viewport_id = ctx.viewport_id();
 
-    /// For integrations: Set this to render a sync viewport.
-    ///
-    /// This will only set the callback for the current thread,
-    /// which most likely should be the main thread.
-    ///
-    /// When an immediate viewport is created with [`Self::show_viewport_immediate`] it will be rendered by this function.
-    ///
-    /// When called, the integration needs to:
-    /// * Check if there already is a window for this viewport id, and if not open one
-    /// * Set the window attributes (position, size, …) based on [`ImmediateViewport::builder`].
-    /// * Call [`Context::run`] with [`ImmediateViewport::viewport_ui_cb`].
-    /// * Handle the output from [`Context::run`], including rendering
-    #[allow(clippy::unused_self)]
-    pub fn set_immediate_viewport_renderer(
-        callback: impl for<'a> Fn(&Self, ImmediateViewport<'a>) + 'static,
-    ) {
-        let callback = Box::new(callback);
-        IMMEDIATE_VIEWPORT_RENDERER.with(|render_sync| {
-            render_sync.replace(Some(callback));
-        });
-    }
+        ctx.viewport_parents.insert(new_viewport_id, parent_viewport_id);
 
-    /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
-    /// embed the new viewports inside the existing one, instead of spawning a new native window.
-    ///
-    /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
-    pub fn embed_viewports(&self) -> bool {
-        self.read(|ctx| ctx.embed_viewports)
-    }
+        let viewport = ctx.viewports.entry(new_viewport_id).or_default();
+        viewport.builder = builder.clone();
+        viewport.used = true;
+        viewport.viewport_ui_cb = None; // it is immediate
 
-    /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
-    /// embed the new viewports inside the existing one, instead of spawning a new native window.
-    ///
-    /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
-    pub fn set_embed_viewports(&self, value: bool) {
-        self.write(|ctx| ctx.embed_viewports = value);
-    }
+        ViewportIdPair::from_self_and_parent(new_viewport_id, parent_viewport_id)
+      });
 
-    /// Send a command to the current viewport.
-    ///
-    /// This lets you affect the current viewport, e.g. resizing the window.
-    pub fn send_viewport_cmd(&self, command: ViewportCommand) {
-        self.send_viewport_cmd_to(self.viewport_id(), command);
-    }
+      let mut out = None;
+      {
+        let out = &mut out;
 
-    /// Send a command to a specific viewport.
-    ///
-    /// This lets you affect another viewport, e.g. resizing its window.
-    pub fn send_viewport_cmd_to(&self, id: ViewportId, command: ViewportCommand) {
-        self.request_repaint_of(id);
+        let viewport = ImmediateViewport {
+          ids,
+          builder,
+          viewport_ui_cb: Box::new(move |context| {
+            *out = Some(viewport_ui_cb(context, ViewportClass::Immediate));
+          }),
+        };
 
-        if command.requires_parent_repaint() {
-            self.request_repaint_of(self.parent_viewport_id());
-        }
+        immediate_viewport_renderer(self, viewport);
+      }
 
-        self.write(|ctx| ctx.viewport_for(id).commands.push(command));
-    }
-
-    /// Show a deferred viewport, creating a new native window, if possible.
-    ///
-    /// The given id must be unique for each viewport.
-    ///
-    /// You need to call this each frame when the child viewport should exist.
-    ///
-    /// You can check if the user wants to close the viewport by checking the
-    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
-    ///
-    /// The given callback will be called whenever the child viewport needs repainting,
-    /// e.g. on an event or when [`Self::request_repaint`] is called.
-    /// This means it may be called multiple times, for instance while the
-    /// parent viewport (the caller) is sleeping but the child viewport is animating.
-    ///
-    /// You will need to wrap your viewport state in an `Arc<RwLock<T>>` or `Arc<Mutex<T>>`.
-    /// When this is called again with the same id in `ViewportBuilder` the render function for that viewport will be updated.
-    ///
-    /// You can also use [`Self::show_viewport_immediate`], which uses a simpler `FnOnce`
-    /// with no need for `Send` or `Sync`. The downside is that it will require
-    /// the parent viewport (the caller) to repaint anytime the child is repainted,
-    /// and vice versa.
-    ///
-    /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
-    /// backend does not support multiple viewports), the given callback
-    /// will be called immediately, embedding the new viewport in the current one.
-    /// You can check this with the [`ViewportClass`] given in the callback.
-    /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
-    ///
-    /// See [`crate::viewport`] for more information about viewports.
-    pub fn show_viewport_deferred(
-        &self,
-        new_viewport_id: ViewportId,
-        viewport_builder: ViewportBuilder,
-        viewport_ui_cb: impl Fn(&Self, ViewportClass) + Send + Sync + 'static,
-    ) {
-        crate::profile_function!();
-
-        if self.embed_viewports() {
-            viewport_ui_cb(self, ViewportClass::Embedded);
-        } else {
-            self.write(|ctx| {
-                ctx.viewport_parents
-                    .insert(new_viewport_id, ctx.viewport_id());
-
-                let viewport = ctx.viewports.entry(new_viewport_id).or_default();
-                viewport.class = ViewportClass::Deferred;
-                viewport.builder = viewport_builder;
-                viewport.used = true;
-                viewport.viewport_ui_cb = Some(Arc::new(move |ctx| {
-                    (viewport_ui_cb)(ctx, ViewportClass::Deferred);
-                }));
-            });
-        }
-    }
-
-    /// Show an immediate viewport, creating a new native window, if possible.
-    ///
-    /// This is the easier type of viewport to use, but it is less performant
-    /// at it requires both parent and child to repaint if any one of them needs repainting,
-    /// which efficvely produce double work for two viewports, and triple work for three viewports, etc.
-    /// To avoid this, use [`Self::show_viewport_deferred`] instead.
-    ///
-    /// The given id must be unique for each viewport.
-    ///
-    /// You need to call this each frame when the child viewport should exist.
-    ///
-    /// You can check if the user wants to close the viewport by checking the
-    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
-    ///
-    /// The given ui function will be called immediately.
-    /// This may only be called on the main thread.
-    /// This call will pause the current viewport and render the child viewport in its own window.
-    /// This means that the child viewport will not be repainted when the parent viewport is repainted, and vice versa.
-    ///
-    /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
-    /// backend does not support multiple viewports), the given callback
-    /// will be called immediately, embedding the new viewport in the current one.
-    /// You can check this with the [`ViewportClass`] given in the callback.
-    /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
-    ///
-    /// See [`crate::viewport`] for more information about viewports.
-    pub fn show_viewport_immediate<T>(
-        &self,
-        new_viewport_id: ViewportId,
-        builder: ViewportBuilder,
-        viewport_ui_cb: impl FnOnce(&Self, ViewportClass) -> T,
-    ) -> T {
-        crate::profile_function!();
-
-        if self.embed_viewports() {
-            return viewport_ui_cb(self, ViewportClass::Embedded);
-        }
-
-        IMMEDIATE_VIEWPORT_RENDERER.with(|immediate_viewport_renderer| {
-            let immediate_viewport_renderer = immediate_viewport_renderer.borrow();
-            let Some(immediate_viewport_renderer) = immediate_viewport_renderer.as_ref() else {
-                // This egui backend does not support multiple viewports.
-                return viewport_ui_cb(self, ViewportClass::Embedded);
-            };
-
-            let ids = self.write(|ctx| {
-                let parent_viewport_id = ctx.viewport_id();
-
-                ctx.viewport_parents
-                    .insert(new_viewport_id, parent_viewport_id);
-
-                let viewport = ctx.viewports.entry(new_viewport_id).or_default();
-                viewport.builder = builder.clone();
-                viewport.used = true;
-                viewport.viewport_ui_cb = None; // it is immediate
-
-                ViewportIdPair::from_self_and_parent(new_viewport_id, parent_viewport_id)
-            });
-
-            let mut out = None;
-            {
-                let out = &mut out;
-
-                let viewport = ImmediateViewport {
-                    ids,
-                    builder,
-                    viewport_ui_cb: Box::new(move |context| {
-                        *out = Some(viewport_ui_cb(context, ViewportClass::Immediate));
-                    }),
-                };
-
-                immediate_viewport_renderer(self, viewport);
-            }
-
-            out.expect(
-                "egui backend is implemented incorrectly - the user callback was never called",
-            )
-        })
-    }
+      out.expect("egui backend is implemented incorrectly - the user callback was never called")
+    })
+  }
 }
 
 /// ## Interaction
 impl Context {
-    /// Read you what widgets are currently being interacted with.
-    pub fn interaction_snapshot<R>(&self, reader: impl FnOnce(&InteractionSnapshot) -> R) -> R {
-        self.write(|w| reader(&w.viewport().interact_widgets))
-    }
+  /// Read you what widgets are currently being interacted with.
+  pub fn interaction_snapshot<R>(&self, reader: impl FnOnce(&InteractionSnapshot) -> R) -> R {
+    self.write(|w| reader(&w.viewport().interact_widgets))
+  }
 
-    /// The widget currently being dragged, if any.
-    ///
-    /// For widgets that sense both clicks and drags, this will
-    /// not be set until the mouse cursor has moved a certain distance.
-    ///
-    /// NOTE: if the widget was released this frame, this will be `None`.
-    /// Use [`Self::drag_stopped_id`] instead.
-    pub fn dragged_id(&self) -> Option<Id> {
-        self.interaction_snapshot(|i| i.dragged)
-    }
+  /// The widget currently being dragged, if any.
+  ///
+  /// For widgets that sense both clicks and drags, this will
+  /// not be set until the mouse cursor has moved a certain distance.
+  ///
+  /// NOTE: if the widget was released this frame, this will be `None`.
+  /// Use [`Self::drag_stopped_id`] instead.
+  pub fn dragged_id(&self) -> Option<Id> {
+    self.interaction_snapshot(|i| i.dragged)
+  }
 
-    /// Is this specific widget being dragged?
-    ///
-    /// A widget that sense both clicks and drags is only marked as "dragged"
-    /// when the mouse has moved a bit
-    ///
-    /// See also: [`crate::Response::dragged`].
-    pub fn is_being_dragged(&self, id: Id) -> bool {
-        self.dragged_id() == Some(id)
-    }
+  /// Is this specific widget being dragged?
+  ///
+  /// A widget that sense both clicks and drags is only marked as "dragged"
+  /// when the mouse has moved a bit
+  ///
+  /// See also: [`crate::Response::dragged`].
+  pub fn is_being_dragged(&self, id: Id) -> bool {
+    self.dragged_id() == Some(id)
+  }
 
-    /// This widget just started being dragged this frame.
-    ///
-    /// The same widget should also be found in [`Self::dragged_id`].
-    pub fn drag_started_id(&self) -> Option<Id> {
-        self.interaction_snapshot(|i| i.drag_started)
-    }
+  /// This widget just started being dragged this frame.
+  ///
+  /// The same widget should also be found in [`Self::dragged_id`].
+  pub fn drag_started_id(&self) -> Option<Id> {
+    self.interaction_snapshot(|i| i.drag_started)
+  }
 
-    /// This widget was being dragged, but was released this frame
-    pub fn drag_stopped_id(&self) -> Option<Id> {
-        self.interaction_snapshot(|i| i.drag_stopped)
-    }
+  /// This widget was being dragged, but was released this frame
+  pub fn drag_stopped_id(&self) -> Option<Id> {
+    self.interaction_snapshot(|i| i.drag_stopped)
+  }
 
-    /// Set which widget is being dragged.
-    pub fn set_dragged_id(&self, id: Id) {
-        self.write(|ctx| {
-            let vp = ctx.viewport();
-            let i = &mut vp.interact_widgets;
-            if i.dragged != Some(id) {
-                i.drag_stopped = i.dragged.or(i.drag_stopped);
-                i.dragged = Some(id);
-                i.drag_started = Some(id);
-            }
+  /// Set which widget is being dragged.
+  pub fn set_dragged_id(&self, id: Id) {
+    self.write(|ctx| {
+      let vp = ctx.viewport();
+      let i = &mut vp.interact_widgets;
+      if i.dragged != Some(id) {
+        i.drag_stopped = i.dragged.or(i.drag_stopped);
+        i.dragged = Some(id);
+        i.drag_started = Some(id);
+      }
 
-            ctx.memory.interaction_mut().potential_drag_id = Some(id);
-        });
-    }
+      ctx.memory.interaction_mut().potential_drag_id = Some(id);
+    });
+  }
 
-    /// Stop dragging any widget.
-    pub fn stop_dragging(&self) {
-        self.write(|ctx| {
-            let vp = ctx.viewport();
-            let i = &mut vp.interact_widgets;
-            if i.dragged.is_some() {
-                i.drag_stopped = i.dragged;
-                i.dragged = None;
-            }
+  /// Stop dragging any widget.
+  pub fn stop_dragging(&self) {
+    self.write(|ctx| {
+      let vp = ctx.viewport();
+      let i = &mut vp.interact_widgets;
+      if i.dragged.is_some() {
+        i.drag_stopped = i.dragged;
+        i.dragged = None;
+      }
 
-            ctx.memory.interaction_mut().potential_drag_id = None;
-        });
-    }
+      ctx.memory.interaction_mut().potential_drag_id = None;
+    });
+  }
 
-    /// Is something else being dragged?
-    ///
-    /// Returns true if we are dragging something, but not the given widget.
-    #[inline(always)]
-    pub fn dragging_something_else(&self, not_this: Id) -> bool {
-        let dragged = self.dragged_id();
-        dragged.is_some() && dragged != Some(not_this)
-    }
+  /// Is something else being dragged?
+  ///
+  /// Returns true if we are dragging something, but not the given widget.
+  #[inline(always)]
+  pub fn dragging_something_else(&self, not_this: Id) -> bool {
+    let dragged = self.dragged_id();
+    dragged.is_some() && dragged != Some(not_this)
+  }
 }
 
 #[test]
 fn context_impl_send_sync() {
-    fn assert_send_sync<T: Send + Sync>() {}
-    assert_send_sync::<Context>();
+  fn assert_send_sync<T: Send + Sync>() {}
+  assert_send_sync::<Context>();
 }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -3,21 +3,23 @@
 use std::{borrow::Cow, cell::RefCell, panic::Location, sync::Arc, time::Duration};
 
 use containers::area::AreaState;
-use epaint::{emath::TSTransform, mutex::*, stats::*, text::Fonts, util::OrderedFloat, TessellationOptions, *};
+use epaint::{
+    emath::TSTransform, mutex::*, stats::*, text::Fonts, util::OrderedFloat, TessellationOptions, *,
+};
 
 use crate::{
-  animation_manager::AnimationManager,
-  data::output::PlatformOutput,
-  frame_state::FrameState,
-  input_state::*,
-  layers::GraphicLayers,
-  load::{Bytes, Loaders, SizedTexture},
-  memory::Options,
-  os::OperatingSystem,
-  output::FullOutput,
-  util::IdTypeMap,
-  viewport::ViewportClass,
-  TextureHandle, ViewportCommand, *,
+    animation_manager::AnimationManager,
+    data::output::PlatformOutput,
+    frame_state::FrameState,
+    input_state::*,
+    layers::GraphicLayers,
+    load::{Bytes, Loaders, SizedTexture},
+    memory::Options,
+    os::OperatingSystem,
+    output::FullOutput,
+    util::IdTypeMap,
+    viewport::ViewportClass,
+    TextureHandle, ViewportCommand, *,
 };
 
 use self::{hit_test::WidgetHits, interaction::InteractionSnapshot};
@@ -27,17 +29,17 @@ use self::{hit_test::WidgetHits, interaction::InteractionSnapshot};
 /// This is given in the callback set by [`Context::set_request_repaint_callback`].
 #[derive(Clone, Copy, Debug)]
 pub struct RequestRepaintInfo {
-  /// This is used to specify what viewport that should repaint.
-  pub viewport_id: ViewportId,
+    /// This is used to specify what viewport that should repaint.
+    pub viewport_id: ViewportId,
 
-  /// Repaint after this duration. If zero, repaint as soon as possible.
-  pub delay: Duration,
+    /// Repaint after this duration. If zero, repaint as soon as possible.
+    pub delay: Duration,
 
-  /// The current frame number.
-  ///
-  /// This can be compared to [`Context::frame_nr`] to see if we've already
-  /// triggered the painting of the next frame.
-  pub current_frame_nr: u64,
+    /// The current frame number.
+    ///
+    /// This can be compared to [`Context::frame_nr`] to see if we've already
+    /// triggered the painting of the next frame.
+    pub current_frame_nr: u64,
 }
 
 // ----------------------------------------------------------------------------
@@ -51,15 +53,19 @@ thread_local! {
 struct WrappedTextureManager(Arc<RwLock<epaint::TextureManager>>);
 
 impl Default for WrappedTextureManager {
-  fn default() -> Self {
-    let mut tex_mngr = epaint::textures::TextureManager::default();
+    fn default() -> Self {
+        let mut tex_mngr = epaint::textures::TextureManager::default();
 
-    // Will be filled in later
-    let font_id = tex_mngr.alloc("egui_font_texture".into(), epaint::FontImage::new([0, 0]).into(), Default::default());
-    assert_eq!(font_id, TextureId::default());
+        // Will be filled in later
+        let font_id = tex_mngr.alloc(
+            "egui_font_texture".into(),
+            epaint::FontImage::new([0, 0]).into(),
+            Default::default(),
+        );
+        assert_eq!(font_id, TextureId::default());
 
-    Self(Arc::new(RwLock::new(tex_mngr)))
-  }
+        Self(Arc::new(RwLock::new(tex_mngr)))
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -69,113 +75,130 @@ pub type ContextCallback = Arc<dyn Fn(&Context) + Send + Sync>;
 
 #[derive(Clone)]
 struct NamedContextCallback {
-  debug_name: &'static str,
-  callback: ContextCallback,
+    debug_name: &'static str,
+    callback: ContextCallback,
 }
 
 /// Callbacks that users can register
 #[derive(Clone, Default)]
 struct Plugins {
-  pub on_begin_frame: Vec<NamedContextCallback>,
-  pub on_end_frame: Vec<NamedContextCallback>,
+    pub on_begin_frame: Vec<NamedContextCallback>,
+    pub on_end_frame: Vec<NamedContextCallback>,
 }
 
 impl Plugins {
-  fn call(ctx: &Context, _cb_name: &str, callbacks: &[NamedContextCallback]) {
-    crate::profile_scope!("plugins", _cb_name);
-    for NamedContextCallback { debug_name: _name, callback } in callbacks {
-      crate::profile_scope!("plugin", _name);
-      (callback)(ctx);
+    fn call(ctx: &Context, _cb_name: &str, callbacks: &[NamedContextCallback]) {
+        crate::profile_scope!("plugins", _cb_name);
+        for NamedContextCallback {
+            debug_name: _name,
+            callback,
+        } in callbacks
+        {
+            crate::profile_scope!("plugin", _name);
+            (callback)(ctx);
+        }
     }
-  }
 
-  fn on_begin_frame(&self, ctx: &Context) {
-    Self::call(ctx, "on_begin_frame", &self.on_begin_frame);
-  }
+    fn on_begin_frame(&self, ctx: &Context) {
+        Self::call(ctx, "on_begin_frame", &self.on_begin_frame);
+    }
 
-  fn on_end_frame(&self, ctx: &Context) {
-    Self::call(ctx, "on_end_frame", &self.on_end_frame);
-  }
+    fn on_end_frame(&self, ctx: &Context) {
+        Self::call(ctx, "on_end_frame", &self.on_end_frame);
+    }
 }
 
 // ----------------------------------------------------------------------------
 
 /// Repaint-logic
 impl ContextImpl {
-  /// This is where we update the repaint logic.
-  fn begin_frame_repaint_logic(&mut self, viewport_id: ViewportId) {
-    let viewport = self.viewports.entry(viewport_id).or_default();
+    /// This is where we update the repaint logic.
+    fn begin_frame_repaint_logic(&mut self, viewport_id: ViewportId) {
+        let viewport = self.viewports.entry(viewport_id).or_default();
 
-    std::mem::swap(&mut viewport.repaint.prev_causes, &mut viewport.repaint.causes);
-    viewport.repaint.causes.clear();
+        std::mem::swap(
+            &mut viewport.repaint.prev_causes,
+            &mut viewport.repaint.causes,
+        );
+        viewport.repaint.causes.clear();
 
-    viewport.repaint.prev_frame_paint_delay = viewport.repaint.repaint_delay;
+        viewport.repaint.prev_frame_paint_delay = viewport.repaint.repaint_delay;
 
-    if viewport.repaint.outstanding == 0 {
-      // We are repainting now, so we can wait a while for the next repaint.
-      viewport.repaint.repaint_delay = Duration::MAX;
-    } else {
-      viewport.repaint.repaint_delay = Duration::ZERO;
-      viewport.repaint.outstanding -= 1;
-      if let Some(callback) = &self.request_repaint_callback {
-        (callback)(RequestRepaintInfo {
-          viewport_id,
-          delay: Duration::ZERO,
-          current_frame_nr: viewport.repaint.frame_nr,
-        });
-      }
-    }
-  }
-
-  fn request_repaint(&mut self, viewport_id: ViewportId, cause: RepaintCause) {
-    self.request_repaint_after(Duration::ZERO, viewport_id, cause);
-  }
-
-  fn request_repaint_after(&mut self, mut delay: Duration, viewport_id: ViewportId, cause: RepaintCause) {
-    let viewport = self.viewports.entry(viewport_id).or_default();
-
-    if delay == Duration::ZERO {
-      // Each request results in two repaints, just to give some things time to settle.
-      // This solves some corner-cases of missing repaints on frame-delayed responses.
-      viewport.repaint.outstanding = 1;
-    } else {
-      // For non-zero delays, we only repaint once, because
-      // otherwise we would just schedule an immediate repaint _now_,
-      // which would then clear the delay and repaint again.
-      // Hovering a tooltip is a good example of a case where we want to repaint after a delay.
+        if viewport.repaint.outstanding == 0 {
+            // We are repainting now, so we can wait a while for the next repaint.
+            viewport.repaint.repaint_delay = Duration::MAX;
+        } else {
+            viewport.repaint.repaint_delay = Duration::ZERO;
+            viewport.repaint.outstanding -= 1;
+            if let Some(callback) = &self.request_repaint_callback {
+                (callback)(RequestRepaintInfo {
+                    viewport_id,
+                    delay: Duration::ZERO,
+                    current_frame_nr: viewport.repaint.frame_nr,
+                });
+            }
+        }
     }
 
-    if let Ok(predicted_frame_time) = Duration::try_from_secs_f32(viewport.input.predicted_dt) {
-      // Make it less likely we over-shoot the target:
-      delay = delay.saturating_sub(predicted_frame_time);
+    fn request_repaint(&mut self, viewport_id: ViewportId, cause: RepaintCause) {
+        self.request_repaint_after(Duration::ZERO, viewport_id, cause);
     }
 
-    viewport.repaint.causes.push(cause);
+    fn request_repaint_after(
+        &mut self,
+        mut delay: Duration,
+        viewport_id: ViewportId,
+        cause: RepaintCause,
+    ) {
+        let viewport = self.viewports.entry(viewport_id).or_default();
 
-    // We save some CPU time by only calling the callback if we need to.
-    // If the new delay is greater or equal to the previous lowest,
-    // it means we have already called the callback, and don't need to do it again.
-    if delay < viewport.repaint.repaint_delay {
-      viewport.repaint.repaint_delay = delay;
+        if delay == Duration::ZERO {
+            // Each request results in two repaints, just to give some things time to settle.
+            // This solves some corner-cases of missing repaints on frame-delayed responses.
+            viewport.repaint.outstanding = 1;
+        } else {
+            // For non-zero delays, we only repaint once, because
+            // otherwise we would just schedule an immediate repaint _now_,
+            // which would then clear the delay and repaint again.
+            // Hovering a tooltip is a good example of a case where we want to repaint after a delay.
+        }
 
-      if let Some(callback) = &self.request_repaint_callback {
-        (callback)(RequestRepaintInfo { viewport_id, delay, current_frame_nr: viewport.repaint.frame_nr });
-      }
+        if let Ok(predicted_frame_time) = Duration::try_from_secs_f32(viewport.input.predicted_dt) {
+            // Make it less likely we over-shoot the target:
+            delay = delay.saturating_sub(predicted_frame_time);
+        }
+
+        viewport.repaint.causes.push(cause);
+
+        // We save some CPU time by only calling the callback if we need to.
+        // If the new delay is greater or equal to the previous lowest,
+        // it means we have already called the callback, and don't need to do it again.
+        if delay < viewport.repaint.repaint_delay {
+            viewport.repaint.repaint_delay = delay;
+
+            if let Some(callback) = &self.request_repaint_callback {
+                (callback)(RequestRepaintInfo {
+                    viewport_id,
+                    delay,
+                    current_frame_nr: viewport.repaint.frame_nr,
+                });
+            }
+        }
     }
-  }
 
-  #[must_use]
-  fn requested_immediate_repaint_prev_frame(&self, viewport_id: &ViewportId) -> bool {
-    self.viewports.get(viewport_id).map_or(false, |v| v.repaint.requested_immediate_repaint_prev_frame())
-  }
+    #[must_use]
+    fn requested_immediate_repaint_prev_frame(&self, viewport_id: &ViewportId) -> bool {
+        self.viewports.get(viewport_id).map_or(false, |v| {
+            v.repaint.requested_immediate_repaint_prev_frame()
+        })
+    }
 
-  #[must_use]
-  fn has_requested_repaint(&self, viewport_id: &ViewportId) -> bool {
-    self
-      .viewports
-      .get(viewport_id)
-      .map_or(false, |v| 0 < v.repaint.outstanding || v.repaint.repaint_delay < Duration::MAX)
-  }
+    #[must_use]
+    fn has_requested_repaint(&self, viewport_id: &ViewportId) -> bool {
+        self.viewports.get(viewport_id).map_or(false, |v| {
+            0 < v.repaint.outstanding || v.repaint.repaint_delay < Duration::MAX
+        })
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -186,402 +209,429 @@ impl ContextImpl {
 /// Things here may move and change without warning.
 #[derive(Default)]
 pub struct ViewportState {
-  /// The type of viewport.
-  ///
-  /// This will never be [`ViewportClass::Embedded`],
-  /// since those don't result in real viewports.
-  pub class: ViewportClass,
+    /// The type of viewport.
+    ///
+    /// This will never be [`ViewportClass::Embedded`],
+    /// since those don't result in real viewports.
+    pub class: ViewportClass,
 
-  /// The latest delta
-  pub builder: ViewportBuilder,
+    /// The latest delta
+    pub builder: ViewportBuilder,
 
-  /// The user-code that shows the GUI, used for deferred viewports.
-  ///
-  /// `None` for immediate viewports.
-  pub viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
+    /// The user-code that shows the GUI, used for deferred viewports.
+    ///
+    /// `None` for immediate viewports.
+    pub viewport_ui_cb: Option<Arc<DeferredViewportUiCallback>>,
 
-  pub input: InputState,
+    pub input: InputState,
 
-  /// State that is collected during a frame and then cleared.
-  pub this_frame: FrameState,
+    /// State that is collected during a frame and then cleared.
+    pub this_frame: FrameState,
 
-  /// The final [`FrameState`] from last frame.
-  ///
-  /// Only read from.
-  pub prev_frame: FrameState,
+    /// The final [`FrameState`] from last frame.
+    ///
+    /// Only read from.
+    pub prev_frame: FrameState,
 
-  /// Has this viewport been updated this frame?
-  pub used: bool,
+    /// Has this viewport been updated this frame?
+    pub used: bool,
 
-  /// State related to repaint scheduling.
-  repaint: ViewportRepaintInfo,
+    /// State related to repaint scheduling.
+    repaint: ViewportRepaintInfo,
 
-  // ----------------------
-  // Updated at the start of the frame:
-  //
-  /// Which widgets are under the pointer?
-  pub hits: WidgetHits,
+    // ----------------------
+    // Updated at the start of the frame:
+    //
+    /// Which widgets are under the pointer?
+    pub hits: WidgetHits,
 
-  /// What widgets are being interacted with this frame?
-  ///
-  /// Based on the widgets from last frame, and input in this frame.
-  pub interact_widgets: InteractionSnapshot,
+    /// What widgets are being interacted with this frame?
+    ///
+    /// Based on the widgets from last frame, and input in this frame.
+    pub interact_widgets: InteractionSnapshot,
 
-  // ----------------------
-  // The output of a frame:
-  //
-  pub graphics: GraphicLayers,
-  // Most of the things in `PlatformOutput` are not actually viewport dependent.
-  pub output: PlatformOutput,
-  pub commands: Vec<ViewportCommand>,
+    // ----------------------
+    // The output of a frame:
+    //
+    pub graphics: GraphicLayers,
+    // Most of the things in `PlatformOutput` are not actually viewport dependent.
+    pub output: PlatformOutput,
+    pub commands: Vec<ViewportCommand>,
 }
 
 /// What called [`Context::request_repaint`]?
 #[derive(Clone)]
 pub struct RepaintCause {
-  /// What file had the call that requested the repaint?
-  pub file: &'static str,
+    /// What file had the call that requested the repaint?
+    pub file: &'static str,
 
-  /// What line number of the call that requested the repaint?
-  pub line: u32,
+    /// What line number of the call that requested the repaint?
+    pub line: u32,
 }
 
 impl std::fmt::Debug for RepaintCause {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}:{}", self.file, self.line)
-  }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.file, self.line)
+    }
 }
 
 impl RepaintCause {
-  /// Capture the file and line number of the call site.
-  #[allow(clippy::new_without_default)]
-  #[track_caller]
-  pub fn new() -> Self {
-    let caller = Location::caller();
-    Self { file: caller.file(), line: caller.line() }
-  }
+    /// Capture the file and line number of the call site.
+    #[allow(clippy::new_without_default)]
+    #[track_caller]
+    pub fn new() -> Self {
+        let caller = Location::caller();
+        Self {
+            file: caller.file(),
+            line: caller.line(),
+        }
+    }
 }
 
 impl std::fmt::Display for RepaintCause {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}:{}", self.file, self.line)
-  }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.file, self.line)
+    }
 }
 
 /// Per-viewport state related to repaint scheduling.
 struct ViewportRepaintInfo {
-  /// Monotonically increasing counter.
-  frame_nr: u64,
+    /// Monotonically increasing counter.
+    frame_nr: u64,
 
-  /// The duration which the backend will poll for new events
-  /// before forcing another egui update, even if there's no new events.
-  ///
-  /// Also used to suppress multiple calls to the repaint callback during the same frame.
-  ///
-  /// This is also returned in [`crate::ViewportOutput`].
-  repaint_delay: Duration,
+    /// The duration which the backend will poll for new events
+    /// before forcing another egui update, even if there's no new events.
+    ///
+    /// Also used to suppress multiple calls to the repaint callback during the same frame.
+    ///
+    /// This is also returned in [`crate::ViewportOutput`].
+    repaint_delay: Duration,
 
-  /// While positive, keep requesting repaints. Decrement at the start of each frame.
-  outstanding: u8,
+    /// While positive, keep requesting repaints. Decrement at the start of each frame.
+    outstanding: u8,
 
-  /// What caused repaints during this frame?
-  causes: Vec<RepaintCause>,
+    /// What caused repaints during this frame?
+    causes: Vec<RepaintCause>,
 
-  /// What triggered a repaint the previous frame?
-  /// (i.e: why are we updating now?)
-  prev_causes: Vec<RepaintCause>,
+    /// What triggered a repaint the previous frame?
+    /// (i.e: why are we updating now?)
+    prev_causes: Vec<RepaintCause>,
 
-  /// What was the output of `repaint_delay` on the previous frame?
-  ///
-  /// If this was zero, we are repainting as quickly as possible
-  /// (as far as we know).
-  prev_frame_paint_delay: Duration,
+    /// What was the output of `repaint_delay` on the previous frame?
+    ///
+    /// If this was zero, we are repainting as quickly as possible
+    /// (as far as we know).
+    prev_frame_paint_delay: Duration,
 }
 
 impl Default for ViewportRepaintInfo {
-  fn default() -> Self {
-    Self {
-      frame_nr: 0,
+    fn default() -> Self {
+        Self {
+            frame_nr: 0,
 
-      // We haven't scheduled a repaint yet.
-      repaint_delay: Duration::MAX,
+            // We haven't scheduled a repaint yet.
+            repaint_delay: Duration::MAX,
 
-      // Let's run a couple of frames at the start, because why not.
-      outstanding: 1,
+            // Let's run a couple of frames at the start, because why not.
+            outstanding: 1,
 
-      causes: Default::default(),
-      prev_causes: Default::default(),
+            causes: Default::default(),
+            prev_causes: Default::default(),
 
-      prev_frame_paint_delay: Duration::MAX,
+            prev_frame_paint_delay: Duration::MAX,
+        }
     }
-  }
 }
 
 impl ViewportRepaintInfo {
-  pub fn requested_immediate_repaint_prev_frame(&self) -> bool {
-    self.prev_frame_paint_delay == Duration::ZERO
-  }
+    pub fn requested_immediate_repaint_prev_frame(&self) -> bool {
+        self.prev_frame_paint_delay == Duration::ZERO
+    }
 }
 
 // ----------------------------------------------------------------------------
 
 #[derive(Default)]
 struct ContextImpl {
-  /// Since we could have multiple viewports across multiple monitors with
-  /// different `pixels_per_point`, we need a `Fonts` instance for each unique
-  /// `pixels_per_point`.
-  /// This is because the `Fonts` depend on `pixels_per_point` for the font atlas
-  /// as well as kerning, font sizes, etc.
-  fonts: std::collections::BTreeMap<OrderedFloat<f32>, Fonts>,
-  font_definitions: FontDefinitions,
+    /// Since we could have multiple viewports across multiple monitors with
+    /// different `pixels_per_point`, we need a `Fonts` instance for each unique
+    /// `pixels_per_point`.
+    /// This is because the `Fonts` depend on `pixels_per_point` for the font atlas
+    /// as well as kerning, font sizes, etc.
+    fonts: std::collections::BTreeMap<OrderedFloat<f32>, Fonts>,
+    font_definitions: FontDefinitions,
 
-  /// MEMBRANE: increased each time the font atlas changes so we can drop any cached galleys.
-  font_generation: usize,
+    /// MEMBRANE: increased each time the font atlas changes so we can drop any cached galleys.
+    font_generation: usize,
 
-  memory: Memory,
-  animation_manager: AnimationManager,
+    memory: Memory,
+    animation_manager: AnimationManager,
 
-  plugins: Plugins,
+    plugins: Plugins,
 
-  /// All viewports share the same texture manager and texture namespace.
-  ///
-  /// In all viewports, [`TextureId::default`] is special, and points to the font atlas.
-  /// The font-atlas texture _may_ be different across viewports, as they may have different
-  /// `pixels_per_point`, so we do special book-keeping for that.
-  /// See <https://github.com/emilk/egui/issues/3664>.
-  tex_manager: WrappedTextureManager,
+    /// All viewports share the same texture manager and texture namespace.
+    ///
+    /// In all viewports, [`TextureId::default`] is special, and points to the font atlas.
+    /// The font-atlas texture _may_ be different across viewports, as they may have different
+    /// `pixels_per_point`, so we do special book-keeping for that.
+    /// See <https://github.com/emilk/egui/issues/3664>.
+    tex_manager: WrappedTextureManager,
 
-  /// Set during the frame, becomes active at the start of the next frame.
-  new_zoom_factor: Option<f32>,
+    /// Set during the frame, becomes active at the start of the next frame.
+    new_zoom_factor: Option<f32>,
 
-  os: OperatingSystem,
+    os: OperatingSystem,
 
-  /// How deeply nested are we?
-  viewport_stack: Vec<ViewportIdPair>,
+    /// How deeply nested are we?
+    viewport_stack: Vec<ViewportIdPair>,
 
-  /// What is the last viewport rendered?
-  last_viewport: ViewportId,
+    /// What is the last viewport rendered?
+    last_viewport: ViewportId,
 
-  paint_stats: PaintStats,
+    paint_stats: PaintStats,
 
-  request_repaint_callback: Option<Box<dyn Fn(RequestRepaintInfo) + Send + Sync>>,
+    request_repaint_callback: Option<Box<dyn Fn(RequestRepaintInfo) + Send + Sync>>,
 
-  viewport_parents: ViewportIdMap<ViewportId>,
-  viewports: ViewportIdMap<ViewportState>,
+    viewport_parents: ViewportIdMap<ViewportId>,
+    viewports: ViewportIdMap<ViewportState>,
 
-  embed_viewports: bool,
+    embed_viewports: bool,
 
-  #[cfg(feature = "accesskit")]
-  is_accesskit_enabled: bool,
-  #[cfg(feature = "accesskit")]
-  accesskit_node_classes: accesskit::NodeClassSet,
+    #[cfg(feature = "accesskit")]
+    is_accesskit_enabled: bool,
+    #[cfg(feature = "accesskit")]
+    accesskit_node_classes: accesskit::NodeClassSet,
 
-  loaders: Arc<Loaders>,
+    loaders: Arc<Loaders>,
 }
 
 impl ContextImpl {
-  fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
-    let viewport_id = new_raw_input.viewport_id;
-    let parent_id = new_raw_input.viewports.get(&viewport_id).and_then(|v| v.parent).unwrap_or_default();
-    let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent_id);
+    fn begin_frame_mut(&mut self, mut new_raw_input: RawInput) {
+        let viewport_id = new_raw_input.viewport_id;
+        let parent_id = new_raw_input
+            .viewports
+            .get(&viewport_id)
+            .and_then(|v| v.parent)
+            .unwrap_or_default();
+        let ids = ViewportIdPair::from_self_and_parent(viewport_id, parent_id);
 
-    let is_outermost_viewport = self.viewport_stack.is_empty(); // not necessarily root, just outermost immediate viewport
-    self.viewport_stack.push(ids);
+        let is_outermost_viewport = self.viewport_stack.is_empty(); // not necessarily root, just outermost immediate viewport
+        self.viewport_stack.push(ids);
 
-    self.begin_frame_repaint_logic(viewport_id);
+        self.begin_frame_repaint_logic(viewport_id);
 
-    let viewport = self.viewports.entry(viewport_id).or_default();
+        let viewport = self.viewports.entry(viewport_id).or_default();
 
-    if is_outermost_viewport {
-      if let Some(new_zoom_factor) = self.new_zoom_factor.take() {
-        let ratio = self.memory.options.zoom_factor / new_zoom_factor;
-        self.memory.options.zoom_factor = new_zoom_factor;
+        if is_outermost_viewport {
+            if let Some(new_zoom_factor) = self.new_zoom_factor.take() {
+                let ratio = self.memory.options.zoom_factor / new_zoom_factor;
+                self.memory.options.zoom_factor = new_zoom_factor;
 
-        let input = &viewport.input;
-        // This is a bit hacky, but is required to avoid jitter:
-        let mut rect = input.screen_rect;
-        rect.min = (ratio * rect.min.to_vec2()).to_pos2();
-        rect.max = (ratio * rect.max.to_vec2()).to_pos2();
-        new_raw_input.screen_rect = Some(rect);
-        // We should really scale everything else in the input too,
-        // but the `screen_rect` is the most important part.
-      }
-    }
-    let native_pixels_per_point = new_raw_input.viewport().native_pixels_per_point.unwrap_or(1.0);
-    let pixels_per_point = self.memory.options.zoom_factor * native_pixels_per_point;
-
-    let all_viewport_ids: ViewportIdSet = self.all_viewport_ids();
-
-    let viewport = self.viewports.entry(self.viewport_id()).or_default();
-
-    self.memory.begin_frame(&new_raw_input, &all_viewport_ids);
-
-    viewport.input = std::mem::take(&mut viewport.input).begin_frame(
-      new_raw_input,
-      viewport.repaint.requested_immediate_repaint_prev_frame(),
-      pixels_per_point,
-      &self.memory.options,
-    );
-
-    let screen_rect = viewport.input.screen_rect;
-
-    viewport.this_frame.begin_frame(screen_rect);
-
-    {
-      let area_order = self.memory.areas().order_map();
-
-      let mut layers: Vec<LayerId> = viewport.prev_frame.widgets.layer_ids().collect();
-
-      layers.sort_by(|a, b| {
-        if a.order == b.order {
-          // Maybe both are windows, so respect area order:
-          area_order.get(a).cmp(&area_order.get(b))
-        } else {
-          // comparing e.g. background to tooltips
-          a.order.cmp(&b.order)
+                let input = &viewport.input;
+                // This is a bit hacky, but is required to avoid jitter:
+                let mut rect = input.screen_rect;
+                rect.min = (ratio * rect.min.to_vec2()).to_pos2();
+                rect.max = (ratio * rect.max.to_vec2()).to_pos2();
+                new_raw_input.screen_rect = Some(rect);
+                // We should really scale everything else in the input too,
+                // but the `screen_rect` is the most important part.
+            }
         }
-      });
+        let native_pixels_per_point = new_raw_input
+            .viewport()
+            .native_pixels_per_point
+            .unwrap_or(1.0);
+        let pixels_per_point = self.memory.options.zoom_factor * native_pixels_per_point;
 
-      viewport.hits = if let Some(pos) = viewport.input.pointer.interact_pos() {
-        let interact_radius = self.memory.options.style.interaction.interact_radius;
+        let all_viewport_ids: ViewportIdSet = self.all_viewport_ids();
 
-        crate::hit_test::hit_test(
-          &viewport.prev_frame.widgets,
-          &layers,
-          &self.memory.layer_transforms,
-          pos,
-          interact_radius,
-        )
-      } else {
-        WidgetHits::default()
-      };
+        let viewport = self.viewports.entry(self.viewport_id()).or_default();
 
-      viewport.interact_widgets = crate::interaction::interact(
-        &viewport.interact_widgets,
-        &viewport.prev_frame.widgets,
-        &viewport.hits,
-        &viewport.input,
-        self.memory.interaction_mut(),
-      );
+        self.memory.begin_frame(&new_raw_input, &all_viewport_ids);
+
+        viewport.input = std::mem::take(&mut viewport.input).begin_frame(
+            new_raw_input,
+            viewport.repaint.requested_immediate_repaint_prev_frame(),
+            pixels_per_point,
+            &self.memory.options,
+        );
+
+        let screen_rect = viewport.input.screen_rect;
+
+        viewport.this_frame.begin_frame(screen_rect);
+
+        {
+            let area_order = self.memory.areas().order_map();
+
+            let mut layers: Vec<LayerId> = viewport.prev_frame.widgets.layer_ids().collect();
+
+            layers.sort_by(|a, b| {
+                if a.order == b.order {
+                    // Maybe both are windows, so respect area order:
+                    area_order.get(a).cmp(&area_order.get(b))
+                } else {
+                    // comparing e.g. background to tooltips
+                    a.order.cmp(&b.order)
+                }
+            });
+
+            viewport.hits = if let Some(pos) = viewport.input.pointer.interact_pos() {
+                let interact_radius = self.memory.options.style.interaction.interact_radius;
+
+                crate::hit_test::hit_test(
+                    &viewport.prev_frame.widgets,
+                    &layers,
+                    &self.memory.layer_transforms,
+                    pos,
+                    interact_radius,
+                )
+            } else {
+                WidgetHits::default()
+            };
+
+            viewport.interact_widgets = crate::interaction::interact(
+                &viewport.interact_widgets,
+                &viewport.prev_frame.widgets,
+                &viewport.hits,
+                &viewport.input,
+                self.memory.interaction_mut(),
+            );
+        }
+
+        // Ensure we register the background area so panels and background ui can catch clicks:
+        self.memory.areas_mut().set_state(
+            LayerId::background(),
+            AreaState {
+                pivot_pos: Some(screen_rect.left_top()),
+                pivot: Align2::LEFT_TOP,
+                size: Some(screen_rect.size()),
+                interactable: true,
+                last_became_visible_at: None,
+            },
+        );
+
+        #[cfg(feature = "accesskit")]
+        if self.is_accesskit_enabled {
+            crate::profile_scope!("accesskit");
+            use crate::frame_state::AccessKitFrameState;
+            let id = crate::accesskit_root_id();
+            let mut builder = accesskit::NodeBuilder::new(accesskit::Role::Window);
+            let pixels_per_point = viewport.input.pixels_per_point();
+            builder.set_transform(accesskit::Affine::scale(pixels_per_point.into()));
+            let mut node_builders = IdMap::default();
+            node_builders.insert(id, builder);
+            viewport.this_frame.accesskit_state = Some(AccessKitFrameState {
+                node_builders,
+                parent_stack: vec![id],
+            });
+        }
+
+        self.update_fonts_mut();
     }
 
-    // Ensure we register the background area so panels and background ui can catch clicks:
-    self.memory.areas_mut().set_state(
-      LayerId::background(),
-      AreaState {
-        pivot_pos: Some(screen_rect.left_top()),
-        pivot: Align2::LEFT_TOP,
-        size: Some(screen_rect.size()),
-        interactable: true,
-        last_became_visible_at: None,
-      },
-    );
+    /// Load fonts unless already loaded.
+    fn update_fonts_mut(&mut self) {
+        crate::profile_function!();
+
+        let input = &self.viewport().input;
+        let pixels_per_point = input.pixels_per_point();
+        let max_texture_side = input.max_texture_side;
+
+        if let Some(font_definitions) = self.memory.new_font_definitions.take() {
+            // New font definition loaded, so we need to reload all fonts.
+            self.fonts.clear();
+            self.font_definitions = font_definitions;
+            #[cfg(feature = "log")]
+            log::debug!("Loading new font definitions");
+        }
+
+        let mut is_new = false;
+
+        let fonts = self
+            .fonts
+            .entry(pixels_per_point.into())
+            .or_insert_with(|| {
+                #[cfg(feature = "log")]
+                log::trace!("Creating new Fonts for pixels_per_point={pixels_per_point}");
+
+                self.font_generation += 1;
+                is_new = true;
+                crate::profile_scope!("Fonts::new");
+                Fonts::new(
+                    pixels_per_point,
+                    max_texture_side,
+                    self.font_definitions.clone(),
+                )
+            });
+
+        {
+            crate::profile_scope!("Fonts::begin_frame");
+            if fonts.begin_frame(pixels_per_point, max_texture_side) {
+                self.font_generation += 1;
+            }
+        }
+
+        if is_new && self.memory.options.preload_font_glyphs {
+            crate::profile_scope!("preload_font_glyphs");
+            // Preload the most common characters for the most common fonts.
+            // This is not very important to do, but may save a few GPU operations.
+            for font_id in self.memory.options.style.text_styles.values() {
+                fonts.lock().fonts.font(font_id).preload_common_characters();
+            }
+        }
+    }
 
     #[cfg(feature = "accesskit")]
-    if self.is_accesskit_enabled {
-      crate::profile_scope!("accesskit");
-      use crate::frame_state::AccessKitFrameState;
-      let id = crate::accesskit_root_id();
-      let mut builder = accesskit::NodeBuilder::new(accesskit::Role::Window);
-      let pixels_per_point = viewport.input.pixels_per_point();
-      builder.set_transform(accesskit::Affine::scale(pixels_per_point.into()));
-      let mut node_builders = IdMap::default();
-      node_builders.insert(id, builder);
-      viewport.this_frame.accesskit_state = Some(AccessKitFrameState { node_builders, parent_stack: vec![id] });
+    fn accesskit_node_builder(&mut self, id: Id) -> &mut accesskit::NodeBuilder {
+        let state = self.viewport().this_frame.accesskit_state.as_mut().unwrap();
+        let builders = &mut state.node_builders;
+        if let std::collections::hash_map::Entry::Vacant(entry) = builders.entry(id) {
+            entry.insert(Default::default());
+            let parent_id = state.parent_stack.last().unwrap();
+            let parent_builder = builders.get_mut(parent_id).unwrap();
+            parent_builder.push_child(id.accesskit_id());
+        }
+        builders.get_mut(&id).unwrap()
     }
 
-    self.update_fonts_mut();
-  }
-
-  /// Load fonts unless already loaded.
-  fn update_fonts_mut(&mut self) {
-    crate::profile_function!();
-
-    let input = &self.viewport().input;
-    let pixels_per_point = input.pixels_per_point();
-    let max_texture_side = input.max_texture_side;
-
-    if let Some(font_definitions) = self.memory.new_font_definitions.take() {
-      // New font definition loaded, so we need to reload all fonts.
-      self.fonts.clear();
-      self.font_definitions = font_definitions;
-      #[cfg(feature = "log")]
-      log::debug!("Loading new font definitions");
+    fn pixels_per_point(&mut self) -> f32 {
+        self.viewport().input.pixels_per_point
     }
 
-    let mut is_new = false;
-
-    let fonts = self.fonts.entry(pixels_per_point.into()).or_insert_with(|| {
-      #[cfg(feature = "log")]
-      log::trace!("Creating new Fonts for pixels_per_point={pixels_per_point}");
-
-      self.font_generation += 1;
-      is_new = true;
-      crate::profile_scope!("Fonts::new");
-      Fonts::new(pixels_per_point, max_texture_side, self.font_definitions.clone())
-    });
-
-    {
-      crate::profile_scope!("Fonts::begin_frame");
-      if fonts.begin_frame(pixels_per_point, max_texture_side) {
-        self.font_generation += 1;
-      }
+    /// Return the `ViewportId` of the current viewport.
+    ///
+    /// For the root viewport this will return [`ViewportId::ROOT`].
+    pub(crate) fn viewport_id(&self) -> ViewportId {
+        self.viewport_stack.last().copied().unwrap_or_default().this
     }
 
-    if is_new && self.memory.options.preload_font_glyphs {
-      crate::profile_scope!("preload_font_glyphs");
-      // Preload the most common characters for the most common fonts.
-      // This is not very important to do, but may save a few GPU operations.
-      for font_id in self.memory.options.style.text_styles.values() {
-        fonts.lock().fonts.font(font_id).preload_common_characters();
-      }
+    /// Return the `ViewportId` of his parent.
+    ///
+    /// For the root viewport this will return [`ViewportId::ROOT`].
+    pub(crate) fn parent_viewport_id(&self) -> ViewportId {
+        let viewport_id = self.viewport_id();
+        *self
+            .viewport_parents
+            .get(&viewport_id)
+            .unwrap_or(&ViewportId::ROOT)
     }
-  }
 
-  #[cfg(feature = "accesskit")]
-  fn accesskit_node_builder(&mut self, id: Id) -> &mut accesskit::NodeBuilder {
-    let state = self.viewport().this_frame.accesskit_state.as_mut().unwrap();
-    let builders = &mut state.node_builders;
-    if let std::collections::hash_map::Entry::Vacant(entry) = builders.entry(id) {
-      entry.insert(Default::default());
-      let parent_id = state.parent_stack.last().unwrap();
-      let parent_builder = builders.get_mut(parent_id).unwrap();
-      parent_builder.push_child(id.accesskit_id());
+    fn all_viewport_ids(&self) -> ViewportIdSet {
+        self.viewports
+            .keys()
+            .copied()
+            .chain([ViewportId::ROOT])
+            .collect()
     }
-    builders.get_mut(&id).unwrap()
-  }
 
-  fn pixels_per_point(&mut self) -> f32 {
-    self.viewport().input.pixels_per_point
-  }
+    /// The current active viewport
+    pub(crate) fn viewport(&mut self) -> &mut ViewportState {
+        self.viewports.entry(self.viewport_id()).or_default()
+    }
 
-  /// Return the `ViewportId` of the current viewport.
-  ///
-  /// For the root viewport this will return [`ViewportId::ROOT`].
-  pub(crate) fn viewport_id(&self) -> ViewportId {
-    self.viewport_stack.last().copied().unwrap_or_default().this
-  }
-
-  /// Return the `ViewportId` of his parent.
-  ///
-  /// For the root viewport this will return [`ViewportId::ROOT`].
-  pub(crate) fn parent_viewport_id(&self) -> ViewportId {
-    let viewport_id = self.viewport_id();
-    *self.viewport_parents.get(&viewport_id).unwrap_or(&ViewportId::ROOT)
-  }
-
-  fn all_viewport_ids(&self) -> ViewportIdSet {
-    self.viewports.keys().copied().chain([ViewportId::ROOT]).collect()
-  }
-
-  /// The current active viewport
-  pub(crate) fn viewport(&mut self) -> &mut ViewportState {
-    self.viewports.entry(self.viewport_id()).or_default()
-  }
-
-  fn viewport_for(&mut self, viewport_id: ViewportId) -> &mut ViewportState {
-    self.viewports.entry(viewport_id).or_default()
-  }
+    fn viewport_for(&mut self, viewport_id: ViewportId) -> &mut ViewportState {
+        self.viewports.entry(viewport_id).or_default()
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -640,303 +690,327 @@ impl ContextImpl {
 pub struct Context(Arc<RwLock<ContextImpl>>);
 
 impl std::fmt::Debug for Context {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("Context").finish_non_exhaustive()
-  }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context").finish_non_exhaustive()
+    }
 }
 
 impl std::cmp::PartialEq for Context {
-  fn eq(&self, other: &Self) -> bool {
-    Arc::ptr_eq(&self.0, &other.0)
-  }
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
 }
 
 impl Default for Context {
-  fn default() -> Self {
-    let ctx_impl = ContextImpl { embed_viewports: true, ..Default::default() };
-    let ctx = Self(Arc::new(RwLock::new(ctx_impl)));
+    fn default() -> Self {
+        let ctx_impl = ContextImpl {
+            embed_viewports: true,
+            ..Default::default()
+        };
+        let ctx = Self(Arc::new(RwLock::new(ctx_impl)));
 
-    // Register built-in plugins:
-    crate::debug_text::register(&ctx);
-    crate::text_selection::LabelSelectionState::register(&ctx);
-    crate::DragAndDrop::register(&ctx);
+        // Register built-in plugins:
+        crate::debug_text::register(&ctx);
+        crate::text_selection::LabelSelectionState::register(&ctx);
+        crate::DragAndDrop::register(&ctx);
 
-    ctx
-  }
+        ctx
+    }
 }
 
 impl Context {
-  /// Do read-only (shared access) transaction on Context
-  fn read<R>(&self, reader: impl FnOnce(&ContextImpl) -> R) -> R {
-    reader(&self.0.read())
-  }
+    /// Do read-only (shared access) transaction on Context
+    fn read<R>(&self, reader: impl FnOnce(&ContextImpl) -> R) -> R {
+        reader(&self.0.read())
+    }
 
-  /// Do read-write (exclusive access) transaction on Context
-  fn write<R>(&self, writer: impl FnOnce(&mut ContextImpl) -> R) -> R {
-    writer(&mut self.0.write())
-  }
+    /// Do read-write (exclusive access) transaction on Context
+    fn write<R>(&self, writer: impl FnOnce(&mut ContextImpl) -> R) -> R {
+        writer(&mut self.0.write())
+    }
 
-  /// Run the ui code for one frame.
-  ///
-  /// Put your widgets into a [`SidePanel`], [`TopBottomPanel`], [`CentralPanel`], [`Window`] or [`Area`].
-  ///
-  /// This will modify the internal reference to point to a new generation of [`Context`].
-  /// Any old clones of this [`Context`] will refer to the old [`Context`], which will not get new input.
-  ///
-  /// You can alternatively run [`Self::begin_frame`] and [`Context::end_frame`].
-  ///
-  /// ```
-  /// // One egui context that you keep reusing:
-  /// let mut ctx = egui::Context::default();
-  ///
-  /// // Each frame:
-  /// let input = egui::RawInput::default();
-  /// let full_output = ctx.run(input, |ctx| {
-  ///     egui::CentralPanel::default().show(&ctx, |ui| {
-  ///         ui.label("Hello egui!");
-  ///     });
-  /// });
-  /// // handle full_output
-  /// ```
-  #[must_use]
-  pub fn run(&self, new_input: RawInput, run_ui: impl FnOnce(&Self)) -> FullOutput {
-    crate::profile_function!();
+    /// Run the ui code for one frame.
+    ///
+    /// Put your widgets into a [`SidePanel`], [`TopBottomPanel`], [`CentralPanel`], [`Window`] or [`Area`].
+    ///
+    /// This will modify the internal reference to point to a new generation of [`Context`].
+    /// Any old clones of this [`Context`] will refer to the old [`Context`], which will not get new input.
+    ///
+    /// You can alternatively run [`Self::begin_frame`] and [`Context::end_frame`].
+    ///
+    /// ```
+    /// // One egui context that you keep reusing:
+    /// let mut ctx = egui::Context::default();
+    ///
+    /// // Each frame:
+    /// let input = egui::RawInput::default();
+    /// let full_output = ctx.run(input, |ctx| {
+    ///     egui::CentralPanel::default().show(&ctx, |ui| {
+    ///         ui.label("Hello egui!");
+    ///     });
+    /// });
+    /// // handle full_output
+    /// ```
+    #[must_use]
+    pub fn run(&self, new_input: RawInput, run_ui: impl FnOnce(&Self)) -> FullOutput {
+        crate::profile_function!();
 
-    self.begin_frame(new_input);
-    run_ui(self);
-    self.end_frame()
-  }
+        self.begin_frame(new_input);
+        run_ui(self);
+        self.end_frame()
+    }
 
-  /// An alternative to calling [`Self::run`].
-  ///
-  /// ```
-  /// // One egui context that you keep reusing:
-  /// let mut ctx = egui::Context::default();
-  ///
-  /// // Each frame:
-  /// let input = egui::RawInput::default();
-  /// ctx.begin_frame(input);
-  ///
-  /// egui::CentralPanel::default().show(&ctx, |ui| {
-  ///     ui.label("Hello egui!");
-  /// });
-  ///
-  /// let full_output = ctx.end_frame();
-  /// // handle full_output
-  /// ```
-  pub fn begin_frame(&self, new_input: RawInput) {
-    crate::profile_function!();
+    /// An alternative to calling [`Self::run`].
+    ///
+    /// ```
+    /// // One egui context that you keep reusing:
+    /// let mut ctx = egui::Context::default();
+    ///
+    /// // Each frame:
+    /// let input = egui::RawInput::default();
+    /// ctx.begin_frame(input);
+    ///
+    /// egui::CentralPanel::default().show(&ctx, |ui| {
+    ///     ui.label("Hello egui!");
+    /// });
+    ///
+    /// let full_output = ctx.end_frame();
+    /// // handle full_output
+    /// ```
+    pub fn begin_frame(&self, new_input: RawInput) {
+        crate::profile_function!();
 
-    self.write(|ctx| ctx.begin_frame_mut(new_input));
+        self.write(|ctx| ctx.begin_frame_mut(new_input));
 
-    // Plugins run just after the frame has started:
-    self.read(|ctx| ctx.plugins.clone()).on_begin_frame(self);
-  }
+        // Plugins run just after the frame has started:
+        self.read(|ctx| ctx.plugins.clone()).on_begin_frame(self);
+    }
 }
 
 /// ## Borrows parts of [`Context`]
 /// These functions all lock the [`Context`].
 /// Please see the documentation of [`Context`] for how locking works!
 impl Context {
-  /// Read-only access to [`InputState`].
-  ///
-  /// Note that this locks the [`Context`].
-  ///
-  /// ```
-  /// # let mut ctx = egui::Context::default();
-  /// ctx.input(|i| {
-  ///     // ⚠️ Using `ctx` (even from other `Arc` reference) again here will lead to a deadlock!
-  /// });
-  ///
-  /// if let Some(pos) = ctx.input(|i| i.pointer.hover_pos()) {
-  ///     // This is fine!
-  /// }
-  /// ```
-  #[inline]
-  pub fn input<R>(&self, reader: impl FnOnce(&InputState) -> R) -> R {
-    self.write(move |ctx| reader(&ctx.viewport().input))
-  }
-
-  /// This will create a `InputState::default()` if there is no input state for that viewport
-  #[inline]
-  pub fn input_for<R>(&self, id: ViewportId, reader: impl FnOnce(&InputState) -> R) -> R {
-    self.write(move |ctx| reader(&ctx.viewport_for(id).input))
-  }
-
-  /// Read-write access to [`InputState`].
-  #[inline]
-  pub fn input_mut<R>(&self, writer: impl FnOnce(&mut InputState) -> R) -> R {
-    self.input_mut_for(self.viewport_id(), writer)
-  }
-
-  /// This will create a `InputState::default()` if there is no input state for that viewport
-  #[inline]
-  pub fn input_mut_for<R>(&self, id: ViewportId, writer: impl FnOnce(&mut InputState) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.viewport_for(id).input))
-  }
-
-  /// Read-only access to [`Memory`].
-  #[inline]
-  pub fn memory<R>(&self, reader: impl FnOnce(&Memory) -> R) -> R {
-    self.read(move |ctx| reader(&ctx.memory))
-  }
-
-  /// Read-write access to [`Memory`].
-  #[inline]
-  pub fn memory_mut<R>(&self, writer: impl FnOnce(&mut Memory) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.memory))
-  }
-
-  /// Read-only access to [`IdTypeMap`], which stores superficial widget state.
-  #[inline]
-  pub fn data<R>(&self, reader: impl FnOnce(&IdTypeMap) -> R) -> R {
-    self.read(move |ctx| reader(&ctx.memory.data))
-  }
-
-  /// Read-write access to [`IdTypeMap`], which stores superficial widget state.
-  #[inline]
-  pub fn data_mut<R>(&self, writer: impl FnOnce(&mut IdTypeMap) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.memory.data))
-  }
-
-  /// Read-write access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
-  #[inline]
-  pub fn graphics_mut<R>(&self, writer: impl FnOnce(&mut GraphicLayers) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.viewport().graphics))
-  }
-
-  /// Read-only access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
-  #[inline]
-  pub fn graphics<R>(&self, reader: impl FnOnce(&GraphicLayers) -> R) -> R {
-    self.write(move |ctx| reader(&ctx.viewport().graphics))
-  }
-
-  /// Read-only access to [`PlatformOutput`].
-  ///
-  /// This is what egui outputs each frame.
-  ///
-  /// ```
-  /// # let mut ctx = egui::Context::default();
-  /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::Progress);
-  /// ```
-  #[inline]
-  pub fn output<R>(&self, reader: impl FnOnce(&PlatformOutput) -> R) -> R {
-    self.write(move |ctx| reader(&ctx.viewport().output))
-  }
-
-  /// Read-write access to [`PlatformOutput`].
-  #[inline]
-  pub fn output_mut<R>(&self, writer: impl FnOnce(&mut PlatformOutput) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.viewport().output))
-  }
-
-  /// Read-only access to [`FrameState`].
-  ///
-  /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
-  #[inline]
-  pub(crate) fn frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
-    self.write(move |ctx| reader(&ctx.viewport().this_frame))
-  }
-
-  /// Read-write access to [`FrameState`].
-  ///
-  /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
-  #[inline]
-  pub(crate) fn frame_state_mut<R>(&self, writer: impl FnOnce(&mut FrameState) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.viewport().this_frame))
-  }
-
-  /// Read-only access to the [`FrameState`] from the previous frame.
-  ///
-  /// This is swapped at the end of each frame.
-  #[inline]
-  pub(crate) fn prev_frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
-    self.write(move |ctx| reader(&ctx.viewport().prev_frame))
-  }
-
-  /// Read-only access to [`Fonts`].
-  ///
-  /// Not valid until first call to [`Context::run()`].
-  /// That's because since we don't know the proper `pixels_per_point` until then.
-  #[inline]
-  pub fn fonts<R>(&self, reader: impl FnOnce(&Fonts) -> R) -> R {
-    self.write(move |ctx| {
-      let pixels_per_point = ctx.pixels_per_point();
-      reader(ctx.fonts.get(&pixels_per_point.into()).expect("No fonts available until first call to Context::run()"))
-    })
-  }
-
-  /// Read-only access to [`Options`].
-  #[inline]
-  pub fn options<R>(&self, reader: impl FnOnce(&Options) -> R) -> R {
-    self.read(move |ctx| reader(&ctx.memory.options))
-  }
-
-  /// Read-write access to [`Options`].
-  #[inline]
-  pub fn options_mut<R>(&self, writer: impl FnOnce(&mut Options) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.memory.options))
-  }
-
-  /// Read-only access to [`TessellationOptions`].
-  #[inline]
-  pub fn tessellation_options<R>(&self, reader: impl FnOnce(&TessellationOptions) -> R) -> R {
-    self.read(move |ctx| reader(&ctx.memory.options.tessellation_options))
-  }
-
-  /// Read-write access to [`TessellationOptions`].
-  #[inline]
-  pub fn tessellation_options_mut<R>(&self, writer: impl FnOnce(&mut TessellationOptions) -> R) -> R {
-    self.write(move |ctx| writer(&mut ctx.memory.options.tessellation_options))
-  }
-
-  /// If the given [`Id`] has been used previously the same frame at different position,
-  /// then an error will be printed on screen.
-  ///
-  /// This function is already called for all widgets that do any interaction,
-  /// but you can call this from widgets that store state but that does not interact.
-  ///
-  /// The given [`Rect`] should be approximately where the widget will be.
-  /// The most important thing is that [`Rect::min`] is approximately correct,
-  /// because that's where the warning will be painted. If you don't know what size to pick, just pick [`Vec2::ZERO`].
-  pub fn check_for_id_clash(&self, id: Id, new_rect: Rect, what: &str) {
-    let prev_rect = self.frame_state_mut(move |state| state.used_ids.insert(id, new_rect));
-
-    if !self.options(|opt| opt.warn_on_id_clash) {
-      return;
+    /// Read-only access to [`InputState`].
+    ///
+    /// Note that this locks the [`Context`].
+    ///
+    /// ```
+    /// # let mut ctx = egui::Context::default();
+    /// ctx.input(|i| {
+    ///     // ⚠️ Using `ctx` (even from other `Arc` reference) again here will lead to a deadlock!
+    /// });
+    ///
+    /// if let Some(pos) = ctx.input(|i| i.pointer.hover_pos()) {
+    ///     // This is fine!
+    /// }
+    /// ```
+    #[inline]
+    pub fn input<R>(&self, reader: impl FnOnce(&InputState) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport().input))
     }
 
-    let Some(prev_rect) = prev_rect else { return };
-
-    // it is ok to reuse the same ID for e.g. a frame around a widget,
-    // or to check for interaction with the same widget twice:
-    let is_same_rect = prev_rect.expand(0.1).contains_rect(new_rect) || new_rect.expand(0.1).contains_rect(prev_rect);
-    if is_same_rect {
-      return;
+    /// This will create a `InputState::default()` if there is no input state for that viewport
+    #[inline]
+    pub fn input_for<R>(&self, id: ViewportId, reader: impl FnOnce(&InputState) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport_for(id).input))
     }
 
-    let show_error = |widget_rect: Rect, text: String| {
-      let screen_rect = self.screen_rect();
+    /// Read-write access to [`InputState`].
+    #[inline]
+    pub fn input_mut<R>(&self, writer: impl FnOnce(&mut InputState) -> R) -> R {
+        self.input_mut_for(self.viewport_id(), writer)
+    }
 
-      let text = format!("🔥 {text}");
-      let color = self.style().visuals.error_fg_color;
-      let painter = self.debug_painter();
-      painter.rect_stroke(widget_rect, 0.0, (1.0, color));
+    /// This will create a `InputState::default()` if there is no input state for that viewport
+    #[inline]
+    pub fn input_mut_for<R>(&self, id: ViewportId, writer: impl FnOnce(&mut InputState) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.viewport_for(id).input))
+    }
 
-      let below = widget_rect.bottom() + 32.0 < screen_rect.bottom();
+    /// Read-only access to [`Memory`].
+    #[inline]
+    pub fn memory<R>(&self, reader: impl FnOnce(&Memory) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory))
+    }
 
-      let text_rect = if below {
-        painter.debug_text(widget_rect.left_bottom() + vec2(0.0, 2.0), Align2::LEFT_TOP, color, text)
-      } else {
-        painter.debug_text(widget_rect.left_top() - vec2(0.0, 2.0), Align2::LEFT_BOTTOM, color, text)
-      };
+    /// Read-write access to [`Memory`].
+    #[inline]
+    pub fn memory_mut<R>(&self, writer: impl FnOnce(&mut Memory) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory))
+    }
 
-      if let Some(pointer_pos) = self.pointer_hover_pos() {
-        if text_rect.contains(pointer_pos) {
-          let tooltip_pos =
-            if below { text_rect.left_bottom() + vec2(2.0, 4.0) } else { text_rect.left_top() + vec2(2.0, -4.0) };
+    /// Read-only access to [`IdTypeMap`], which stores superficial widget state.
+    #[inline]
+    pub fn data<R>(&self, reader: impl FnOnce(&IdTypeMap) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory.data))
+    }
 
-          painter.error(
+    /// Read-write access to [`IdTypeMap`], which stores superficial widget state.
+    #[inline]
+    pub fn data_mut<R>(&self, writer: impl FnOnce(&mut IdTypeMap) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory.data))
+    }
+
+    /// Read-write access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
+    #[inline]
+    pub fn graphics_mut<R>(&self, writer: impl FnOnce(&mut GraphicLayers) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.viewport().graphics))
+    }
+
+    /// Read-only access to [`GraphicLayers`], where painted [`crate::Shape`]s are written to.
+    #[inline]
+    pub fn graphics<R>(&self, reader: impl FnOnce(&GraphicLayers) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport().graphics))
+    }
+
+    /// Read-only access to [`PlatformOutput`].
+    ///
+    /// This is what egui outputs each frame.
+    ///
+    /// ```
+    /// # let mut ctx = egui::Context::default();
+    /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::Progress);
+    /// ```
+    #[inline]
+    pub fn output<R>(&self, reader: impl FnOnce(&PlatformOutput) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport().output))
+    }
+
+    /// Read-write access to [`PlatformOutput`].
+    #[inline]
+    pub fn output_mut<R>(&self, writer: impl FnOnce(&mut PlatformOutput) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.viewport().output))
+    }
+
+    /// Read-only access to [`FrameState`].
+    ///
+    /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
+    #[inline]
+    pub(crate) fn frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport().this_frame))
+    }
+
+    /// Read-write access to [`FrameState`].
+    ///
+    /// This is only valid between [`Context::begin_frame`] and [`Context::end_frame`].
+    #[inline]
+    pub(crate) fn frame_state_mut<R>(&self, writer: impl FnOnce(&mut FrameState) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.viewport().this_frame))
+    }
+
+    /// Read-only access to the [`FrameState`] from the previous frame.
+    ///
+    /// This is swapped at the end of each frame.
+    #[inline]
+    pub(crate) fn prev_frame_state<R>(&self, reader: impl FnOnce(&FrameState) -> R) -> R {
+        self.write(move |ctx| reader(&ctx.viewport().prev_frame))
+    }
+
+    /// Read-only access to [`Fonts`].
+    ///
+    /// Not valid until first call to [`Context::run()`].
+    /// That's because since we don't know the proper `pixels_per_point` until then.
+    #[inline]
+    pub fn fonts<R>(&self, reader: impl FnOnce(&Fonts) -> R) -> R {
+        self.write(move |ctx| {
+            let pixels_per_point = ctx.pixels_per_point();
+            reader(
+                ctx.fonts
+                    .get(&pixels_per_point.into())
+                    .expect("No fonts available until first call to Context::run()"),
+            )
+        })
+    }
+
+    /// Read-only access to [`Options`].
+    #[inline]
+    pub fn options<R>(&self, reader: impl FnOnce(&Options) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory.options))
+    }
+
+    /// Read-write access to [`Options`].
+    #[inline]
+    pub fn options_mut<R>(&self, writer: impl FnOnce(&mut Options) -> R) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory.options))
+    }
+
+    /// Read-only access to [`TessellationOptions`].
+    #[inline]
+    pub fn tessellation_options<R>(&self, reader: impl FnOnce(&TessellationOptions) -> R) -> R {
+        self.read(move |ctx| reader(&ctx.memory.options.tessellation_options))
+    }
+
+    /// Read-write access to [`TessellationOptions`].
+    #[inline]
+    pub fn tessellation_options_mut<R>(
+        &self,
+        writer: impl FnOnce(&mut TessellationOptions) -> R,
+    ) -> R {
+        self.write(move |ctx| writer(&mut ctx.memory.options.tessellation_options))
+    }
+
+    /// If the given [`Id`] has been used previously the same frame at different position,
+    /// then an error will be printed on screen.
+    ///
+    /// This function is already called for all widgets that do any interaction,
+    /// but you can call this from widgets that store state but that does not interact.
+    ///
+    /// The given [`Rect`] should be approximately where the widget will be.
+    /// The most important thing is that [`Rect::min`] is approximately correct,
+    /// because that's where the warning will be painted. If you don't know what size to pick, just pick [`Vec2::ZERO`].
+    pub fn check_for_id_clash(&self, id: Id, new_rect: Rect, what: &str) {
+        let prev_rect = self.frame_state_mut(move |state| state.used_ids.insert(id, new_rect));
+
+        if !self.options(|opt| opt.warn_on_id_clash) {
+            return;
+        }
+
+        let Some(prev_rect) = prev_rect else { return };
+
+        // it is ok to reuse the same ID for e.g. a frame around a widget,
+        // or to check for interaction with the same widget twice:
+        let is_same_rect = prev_rect.expand(0.1).contains_rect(new_rect)
+            || new_rect.expand(0.1).contains_rect(prev_rect);
+        if is_same_rect {
+            return;
+        }
+
+        let show_error = |widget_rect: Rect, text: String| {
+            let screen_rect = self.screen_rect();
+
+            let text = format!("🔥 {text}");
+            let color = self.style().visuals.error_fg_color;
+            let painter = self.debug_painter();
+            painter.rect_stroke(widget_rect, 0.0, (1.0, color));
+
+            let below = widget_rect.bottom() + 32.0 < screen_rect.bottom();
+
+            let text_rect = if below {
+                painter.debug_text(
+                    widget_rect.left_bottom() + vec2(0.0, 2.0),
+                    Align2::LEFT_TOP,
+                    color,
+                    text,
+                )
+            } else {
+                painter.debug_text(
+                    widget_rect.left_top() - vec2(0.0, 2.0),
+                    Align2::LEFT_BOTTOM,
+                    color,
+                    text,
+                )
+            };
+
+            if let Some(pointer_pos) = self.pointer_hover_pos() {
+                if text_rect.contains(pointer_pos) {
+                    let tooltip_pos = if below {
+                        text_rect.left_bottom() + vec2(2.0, 4.0)
+                    } else {
+                        text_rect.left_top() + vec2(2.0, -4.0)
+                    };
+
+                    painter.error(
             tooltip_pos,
             format!(
               "Widget is {} this text.\n\n\
@@ -946,1095 +1020,1197 @@ impl Context {
               if below { "above" } else { "below" }
             ),
           );
+                }
+            }
+        };
+
+        let id_str = id.short_debug_format();
+
+        if prev_rect.min.distance(new_rect.min) < 4.0 {
+            show_error(new_rect, format!("Double use of {what} ID {id_str}"));
+        } else {
+            show_error(prev_rect, format!("First use of {what} ID {id_str}"));
+            show_error(new_rect, format!("Second use of {what} ID {id_str}"));
         }
-      }
-    };
-
-    let id_str = id.short_debug_format();
-
-    if prev_rect.min.distance(new_rect.min) < 4.0 {
-      show_error(new_rect, format!("Double use of {what} ID {id_str}"));
-    } else {
-      show_error(prev_rect, format!("First use of {what} ID {id_str}"));
-      show_error(new_rect, format!("Second use of {what} ID {id_str}"));
-    }
-  }
-
-  // ---------------------------------------------------------------------
-
-  /// Create a widget and check for interaction.
-  ///
-  /// If this is not called, the widget doesn't exist.
-  ///
-  /// You should use [`Ui::interact`] instead.
-  ///
-  /// If the widget already exists, its state (sense, Rect, etc) will be updated.
-  #[allow(clippy::too_many_arguments)]
-  pub(crate) fn create_widget(&self, w: WidgetRect) -> Response {
-    // Remember this widget
-    self.write(|ctx| {
-      let viewport = ctx.viewport();
-
-      // We add all widgets here, even non-interactive ones,
-      // because we need this list not only for checking for blocking widgets,
-      // but also to know when we have reached the widget we are checking for cover.
-      viewport.this_frame.widgets.insert(w.layer_id, w);
-
-      if w.sense.focusable {
-        ctx.memory.interested_in_focus(w.id);
-      }
-    });
-
-    if !w.enabled || !w.sense.focusable || !w.layer_id.allow_interaction() {
-      // Not interested or allowed input:
-      self.memory_mut(|mem| mem.surrender_focus(w.id));
     }
 
-    if w.sense.interactive() || w.sense.focusable {
-      self.check_for_id_clash(w.id, w.rect, "widget");
+    // ---------------------------------------------------------------------
+
+    /// Create a widget and check for interaction.
+    ///
+    /// If this is not called, the widget doesn't exist.
+    ///
+    /// You should use [`Ui::interact`] instead.
+    ///
+    /// If the widget already exists, its state (sense, Rect, etc) will be updated.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn create_widget(&self, w: WidgetRect) -> Response {
+        // Remember this widget
+        self.write(|ctx| {
+            let viewport = ctx.viewport();
+
+            // We add all widgets here, even non-interactive ones,
+            // because we need this list not only for checking for blocking widgets,
+            // but also to know when we have reached the widget we are checking for cover.
+            viewport.this_frame.widgets.insert(w.layer_id, w);
+
+            if w.sense.focusable {
+                ctx.memory.interested_in_focus(w.id);
+            }
+        });
+
+        if !w.enabled || !w.sense.focusable || !w.layer_id.allow_interaction() {
+            // Not interested or allowed input:
+            self.memory_mut(|mem| mem.surrender_focus(w.id));
+        }
+
+        if w.sense.interactive() || w.sense.focusable {
+            self.check_for_id_clash(w.id, w.rect, "widget");
+        }
+
+        #[allow(clippy::let_and_return)]
+        let res = self.get_response(w);
+
+        #[cfg(feature = "accesskit")]
+        if w.sense.focusable {
+            // Make sure anything that can receive focus has an AccessKit node.
+            // TODO(mwcampbell): For nodes that are filled from widget info,
+            // some information is written to the node twice.
+            self.accesskit_node_builder(w.id, |builder| res.fill_accesskit_node_common(builder));
+        }
+
+        res
     }
 
-    #[allow(clippy::let_and_return)]
-    let res = self.get_response(w);
-
-    #[cfg(feature = "accesskit")]
-    if w.sense.focusable {
-      // Make sure anything that can receive focus has an AccessKit node.
-      // TODO(mwcampbell): For nodes that are filled from widget info,
-      // some information is written to the node twice.
-      self.accesskit_node_builder(w.id, |builder| res.fill_accesskit_node_common(builder));
+    /// Read the response of some widget, which may be called _before_ creating the widget (!).
+    ///
+    /// This is because widget interaction happens at the start of the frame, using the previous frame's widgets.
+    ///
+    /// If the widget was not visible the previous frame (or this frame), this will return `None`.
+    pub fn read_response(&self, id: Id) -> Option<Response> {
+        self.write(|ctx| {
+            let viewport = ctx.viewport();
+            viewport
+                .this_frame
+                .widgets
+                .get(id)
+                .or_else(|| viewport.prev_frame.widgets.get(id))
+                .copied()
+        })
+        .map(|widget_rect| self.get_response(widget_rect))
     }
 
-    res
-  }
+    /// Returns `true` if the widget with the given `Id` contains the pointer.
+    #[deprecated = "Use Response.contains_pointer or Context::read_response instead"]
+    pub fn widget_contains_pointer(&self, id: Id) -> bool {
+        self.read_response(id)
+            .map_or(false, |response| response.contains_pointer)
+    }
 
-  /// Read the response of some widget, which may be called _before_ creating the widget (!).
-  ///
-  /// This is because widget interaction happens at the start of the frame, using the previous frame's widgets.
-  ///
-  /// If the widget was not visible the previous frame (or this frame), this will return `None`.
-  pub fn read_response(&self, id: Id) -> Option<Response> {
-    self
-      .write(|ctx| {
-        let viewport = ctx.viewport();
-        viewport.this_frame.widgets.get(id).or_else(|| viewport.prev_frame.widgets.get(id)).copied()
-      })
-      .map(|widget_rect| self.get_response(widget_rect))
-  }
+    /// Do all interaction for an existing widget, without (re-)registering it.
+    fn get_response(&self, widget_rect: WidgetRect) -> Response {
+        let WidgetRect {
+            id,
+            layer_id,
+            rect,
+            interact_rect,
+            sense,
+            enabled,
+        } = widget_rect;
 
-  /// Returns `true` if the widget with the given `Id` contains the pointer.
-  #[deprecated = "Use Response.contains_pointer or Context::read_response instead"]
-  pub fn widget_contains_pointer(&self, id: Id) -> bool {
-    self.read_response(id).map_or(false, |response| response.contains_pointer)
-  }
+        // previous frame + "highlight next frame" == "highlight this frame"
+        let highlighted = self.prev_frame_state(|fs| fs.highlight_next_frame.contains(&id));
 
-  /// Do all interaction for an existing widget, without (re-)registering it.
-  fn get_response(&self, widget_rect: WidgetRect) -> Response {
-    let WidgetRect { id, layer_id, rect, interact_rect, sense, enabled } = widget_rect;
+        let mut res = Response {
+            ctx: self.clone(),
+            layer_id,
+            id,
+            rect,
+            interact_rect,
+            sense,
+            enabled,
+            contains_pointer: false,
+            hovered: false,
+            highlighted,
+            clicked: false,
+            fake_primary_click: false,
+            long_touched: false,
+            drag_started: false,
+            dragged: false,
+            drag_stopped: false,
+            is_pointer_button_down_on: false,
+            interact_pointer_pos: None,
+            changed: false,
+        };
 
-    // previous frame + "highlight next frame" == "highlight this frame"
-    let highlighted = self.prev_frame_state(|fs| fs.highlight_next_frame.contains(&id));
+        self.write(|ctx| {
+            let viewport = ctx.viewports.entry(ctx.viewport_id()).or_default();
 
-    let mut res = Response {
-      ctx: self.clone(),
-      layer_id,
-      id,
-      rect,
-      interact_rect,
-      sense,
-      enabled,
-      contains_pointer: false,
-      hovered: false,
-      highlighted,
-      clicked: false,
-      fake_primary_click: false,
-      long_touched: false,
-      drag_started: false,
-      dragged: false,
-      drag_stopped: false,
-      is_pointer_button_down_on: false,
-      interact_pointer_pos: None,
-      changed: false,
-    };
+            res.contains_pointer = viewport.interact_widgets.contains_pointer.contains(&id);
 
-    self.write(|ctx| {
-      let viewport = ctx.viewports.entry(ctx.viewport_id()).or_default();
+            let input = &viewport.input;
+            let memory = &mut ctx.memory;
 
-      res.contains_pointer = viewport.interact_widgets.contains_pointer.contains(&id);
-
-      let input = &viewport.input;
-      let memory = &mut ctx.memory;
-
-      if enabled
-        && sense.click
-        && memory.has_focus(id)
-        && (input.key_pressed(Key::Space) || input.key_pressed(Key::Enter))
-      {
-        // Space/enter works like a primary click for e.g. selected buttons
-        res.fake_primary_click = true;
-      }
-
-      #[cfg(feature = "accesskit")]
-      if enabled && sense.click && input.has_accesskit_action_request(id, accesskit::Action::Default) {
-        res.fake_primary_click = true;
-      }
-
-      if enabled && sense.click && Some(id) == viewport.interact_widgets.long_touched {
-        res.long_touched = true;
-      }
-
-      let interaction = memory.interaction();
-
-      res.is_pointer_button_down_on =
-        interaction.potential_click_id == Some(id) || interaction.potential_drag_id == Some(id);
-
-      if res.enabled {
-        res.hovered = viewport.interact_widgets.hovered.contains(&id);
-        res.dragged = Some(id) == viewport.interact_widgets.dragged;
-        res.drag_started = Some(id) == viewport.interact_widgets.drag_started;
-        res.drag_stopped = Some(id) == viewport.interact_widgets.drag_stopped;
-      }
-
-      let clicked = Some(id) == viewport.interact_widgets.clicked;
-      let mut any_press = false;
-
-      for pointer_event in &input.pointer.pointer_events {
-        match pointer_event {
-          PointerEvent::Moved(_) => {}
-          PointerEvent::Pressed { .. } => {
-            any_press = true;
-          }
-          PointerEvent::Released { click, .. } => {
-            if enabled && sense.click && clicked && click.is_some() {
-              res.clicked = true;
+            if enabled
+                && sense.click
+                && memory.has_focus(id)
+                && (input.key_pressed(Key::Space) || input.key_pressed(Key::Enter))
+            {
+                // Space/enter works like a primary click for e.g. selected buttons
+                res.fake_primary_click = true;
             }
 
-            res.is_pointer_button_down_on = false;
-            res.dragged = false;
-          }
-        }
-      }
+            #[cfg(feature = "accesskit")]
+            if enabled
+                && sense.click
+                && input.has_accesskit_action_request(id, accesskit::Action::Default)
+            {
+                res.fake_primary_click = true;
+            }
 
-      // is_pointer_button_down_on is false when released, but we want interact_pointer_pos
-      // to still work.
-      let is_interacted_with = res.is_pointer_button_down_on || res.long_touched || clicked || res.drag_stopped;
-      if is_interacted_with {
-        res.interact_pointer_pos = input.pointer.interact_pos();
-        if let (Some(transform), Some(pos)) =
-          (memory.layer_transforms.get(&res.layer_id), &mut res.interact_pointer_pos)
+            if enabled && sense.click && Some(id) == viewport.interact_widgets.long_touched {
+                res.long_touched = true;
+            }
+
+            let interaction = memory.interaction();
+
+            res.is_pointer_button_down_on = interaction.potential_click_id == Some(id)
+                || interaction.potential_drag_id == Some(id);
+
+            if res.enabled {
+                res.hovered = viewport.interact_widgets.hovered.contains(&id);
+                res.dragged = Some(id) == viewport.interact_widgets.dragged;
+                res.drag_started = Some(id) == viewport.interact_widgets.drag_started;
+                res.drag_stopped = Some(id) == viewport.interact_widgets.drag_stopped;
+            }
+
+            let clicked = Some(id) == viewport.interact_widgets.clicked;
+            let mut any_press = false;
+
+            for pointer_event in &input.pointer.pointer_events {
+                match pointer_event {
+                    PointerEvent::Moved(_) => {}
+                    PointerEvent::Pressed { .. } => {
+                        any_press = true;
+                    }
+                    PointerEvent::Released { click, .. } => {
+                        if enabled && sense.click && clicked && click.is_some() {
+                            res.clicked = true;
+                        }
+
+                        res.is_pointer_button_down_on = false;
+                        res.dragged = false;
+                    }
+                }
+            }
+
+            // is_pointer_button_down_on is false when released, but we want interact_pointer_pos
+            // to still work.
+            let is_interacted_with =
+                res.is_pointer_button_down_on || res.long_touched || clicked || res.drag_stopped;
+            if is_interacted_with {
+                res.interact_pointer_pos = input.pointer.interact_pos();
+                if let (Some(transform), Some(pos)) = (
+                    memory.layer_transforms.get(&res.layer_id),
+                    &mut res.interact_pointer_pos,
+                ) {
+                    *pos = transform.inverse() * *pos;
+                }
+            }
+
+            if input.pointer.any_down() && !is_interacted_with {
+                // We don't hover widgets while interacting with *other* widgets:
+                res.hovered = false;
+            }
+
+            let pointer_pressed_elsewhere = any_press && !res.hovered;
+            if pointer_pressed_elsewhere && memory.has_focus(id) {
+                memory.surrender_focus(id);
+            }
+        });
+
+        res
+    }
+
+    /// This is called by [`Response::widget_info`], but can also be called directly.
+    ///
+    /// With some debug flags it will store the widget info in [`WidgetRects`] for later display.
+    #[inline]
+    pub fn register_widget_info(&self, id: Id, make_info: impl Fn() -> crate::WidgetInfo) {
+        #[cfg(debug_assertions)]
+        self.write(|ctx| {
+            if ctx.memory.options.style.debug.show_interactive_widgets {
+                ctx.viewport().this_frame.widgets.set_info(id, make_info());
+            }
+        });
+
+        #[cfg(not(debug_assertions))]
         {
-          *pos = transform.inverse() * *pos;
+            _ = (self, id, make_info);
         }
-      }
-
-      if input.pointer.any_down() && !is_interacted_with {
-        // We don't hover widgets while interacting with *other* widgets:
-        res.hovered = false;
-      }
-
-      let pointer_pressed_elsewhere = any_press && !res.hovered;
-      if pointer_pressed_elsewhere && memory.has_focus(id) {
-        memory.surrender_focus(id);
-      }
-    });
-
-    res
-  }
-
-  /// This is called by [`Response::widget_info`], but can also be called directly.
-  ///
-  /// With some debug flags it will store the widget info in [`WidgetRects`] for later display.
-  #[inline]
-  pub fn register_widget_info(&self, id: Id, make_info: impl Fn() -> crate::WidgetInfo) {
-    #[cfg(debug_assertions)]
-    self.write(|ctx| {
-      if ctx.memory.options.style.debug.show_interactive_widgets {
-        ctx.viewport().this_frame.widgets.set_info(id, make_info());
-      }
-    });
-
-    #[cfg(not(debug_assertions))]
-    {
-      _ = (self, id, make_info);
     }
-  }
 
-  /// Get a full-screen painter for a new or existing layer
-  pub fn layer_painter(&self, layer_id: LayerId) -> Painter {
-    let screen_rect = self.screen_rect();
-    Painter::new(self.clone(), layer_id, screen_rect)
-  }
-
-  /// Paint on top of everything else
-  pub fn debug_painter(&self) -> Painter {
-    Self::layer_painter(self, LayerId::debug())
-  }
-
-  /// Print this text next to the cursor at the end of the frame.
-  ///
-  /// If you call this multiple times, the text will be appended.
-  ///
-  /// This only works if compiled with `debug_assertions`.
-  ///
-  /// ```
-  /// # let ctx = egui::Context::default();
-  /// # let state = true;
-  /// ctx.debug_text(format!("State: {state:?}"));
-  /// ```
-  ///
-  /// This is just a convenience for calling [`crate::debug_text::print`].
-  #[track_caller]
-  pub fn debug_text(&self, text: impl Into<WidgetText>) {
-    crate::debug_text::print(self, text);
-  }
-
-  /// What operating system are we running on?
-  ///
-  /// When compiling natively, this is
-  /// figured out from the `target_os`.
-  ///
-  /// For web, this can be figured out from the user-agent,
-  /// and is done so by [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe).
-  pub fn os(&self) -> OperatingSystem {
-    self.read(|ctx| ctx.os)
-  }
-
-  /// Set the operating system we are running on.
-  ///
-  /// If you are writing wasm-based integration for egui you
-  /// may want to set this based on e.g. the user-agent.
-  pub fn set_os(&self, os: OperatingSystem) {
-    self.write(|ctx| ctx.os = os);
-  }
-
-  /// Set the cursor icon.
-  ///
-  /// Equivalent to:
-  /// ```
-  /// # let ctx = egui::Context::default();
-  /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
-  /// ```
-  pub fn set_cursor_icon(&self, cursor_icon: CursorIcon) {
-    self.output_mut(|o| o.cursor_icon = cursor_icon);
-  }
-
-  /// Open an URL in a browser.
-  ///
-  /// Equivalent to:
-  /// ```
-  /// # let ctx = egui::Context::default();
-  /// # let open_url = egui::OpenUrl::same_tab("http://www.example.com");
-  /// ctx.output_mut(|o| o.open_url = Some(open_url));
-  /// ```
-  pub fn open_url(&self, open_url: crate::OpenUrl) {
-    self.output_mut(|o| o.open_url = Some(open_url));
-  }
-
-  /// Copy the given text to the system clipboard.
-  ///
-  /// Empty strings are ignored.
-  ///
-  /// Equivalent to:
-  /// ```
-  /// # let ctx = egui::Context::default();
-  /// ctx.output_mut(|o| o.copied_text = "Copy this".to_owned());
-  /// ```
-  pub fn copy_text(&self, text: String) {
-    self.output_mut(|o| o.copied_text = text);
-  }
-
-  /// Format the given shortcut in a human-readable way (e.g. `Ctrl+Shift+X`).
-  ///
-  /// Can be used to get the text for [`Button::shortcut_text`].
-  pub fn format_shortcut(&self, shortcut: &KeyboardShortcut) -> String {
-    let os = self.os();
-
-    let is_mac = matches!(os, OperatingSystem::Mac | OperatingSystem::IOS);
-
-    let can_show_symbols = || {
-      let ModifierNames { alt, ctrl, shift, mac_cmd, .. } = ModifierNames::SYMBOLS;
-
-      let font_id = TextStyle::Body.resolve(&self.style());
-      self.fonts(|f| {
-        let mut lock = f.lock();
-        let font = lock.fonts.font(&font_id);
-        font.has_glyphs(alt) && font.has_glyphs(ctrl) && font.has_glyphs(shift) && font.has_glyphs(mac_cmd)
-      })
-    };
-
-    if is_mac && can_show_symbols() {
-      shortcut.format(&ModifierNames::SYMBOLS, is_mac)
-    } else {
-      shortcut.format(&ModifierNames::NAMES, is_mac)
+    /// Get a full-screen painter for a new or existing layer
+    pub fn layer_painter(&self, layer_id: LayerId) -> Painter {
+        let screen_rect = self.screen_rect();
+        Painter::new(self.clone(), layer_id, screen_rect)
     }
-  }
 
-  /// The current frame number for the current viewport.
-  ///
-  /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
-  ///
-  /// Between calls to [`Self::run`], this is the frame number of the coming frame.
-  pub fn frame_nr(&self) -> u64 {
-    self.frame_nr_for(self.viewport_id())
-  }
-
-  /// The current frame number.
-  ///
-  /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
-  ///
-  /// Between calls to [`Self::run`], this is the frame number of the coming frame.
-  pub fn frame_nr_for(&self, id: ViewportId) -> u64 {
-    self.read(|ctx| ctx.viewports.get(&id).map_or(0, |v| v.repaint.frame_nr))
-  }
-
-  /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
-  ///
-  /// If this is called at least once in a frame, then there will be another frame right after this.
-  /// Call as many times as you wish, only one repaint will be issued.
-  ///
-  /// To request repaint with a delay, use [`Self::request_repaint_after`].
-  ///
-  /// If called from outside the UI thread, the UI thread will wake up and run,
-  /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
-  /// (this will work on `eframe`).
-  ///
-  /// This will repaint the current viewport.
-  #[track_caller]
-  pub fn request_repaint(&self) {
-    self.request_repaint_of(self.viewport_id());
-  }
-
-  /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
-  ///
-  /// If this is called at least once in a frame, then there will be another frame right after this.
-  /// Call as many times as you wish, only one repaint will be issued.
-  ///
-  /// To request repaint with a delay, use [`Self::request_repaint_after_for`].
-  ///
-  /// If called from outside the UI thread, the UI thread will wake up and run,
-  /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
-  /// (this will work on `eframe`).
-  ///
-  /// This will repaint the specified viewport.
-  #[track_caller]
-  pub fn request_repaint_of(&self, id: ViewportId) {
-    let cause = RepaintCause::new();
-    self.write(|ctx| ctx.request_repaint(id, cause));
-  }
-
-  /// Request repaint after at most the specified duration elapses.
-  ///
-  /// The backend can chose to repaint sooner, for instance if some other code called
-  /// this method with a lower duration, or if new events arrived.
-  ///
-  /// The function can be multiple times, but only the *smallest* duration will be considered.
-  /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
-  /// after `1 second`
-  ///
-  /// This is primarily useful for applications who would like to save battery by avoiding wasted
-  /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
-  /// and outdated if it is not updated for too long.
-  ///
-  /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
-  /// resources repainting multiple times within the same second (when you have no input),
-  /// just calculate the difference of duration between current time and next second change,
-  /// and call this function, to make sure that you are displaying the latest updated time, but
-  /// not wasting resources on needless repaints within the same second.
-  ///
-  /// ### Quirk:
-  /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
-  /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
-  /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
-  /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
-  /// So, it's not that we are requesting repaint within X duration. We are rather timing out
-  /// during app idle time where we are not receiving any new input events.
-  ///
-  /// This repaints the current viewport
-  #[track_caller]
-  pub fn request_repaint_after(&self, duration: Duration) {
-    self.request_repaint_after_for(duration, self.viewport_id());
-  }
-
-  /// Repaint after this many seconds.
-  ///
-  /// See [`Self::request_repaint_after`] for details.
-  #[track_caller]
-  pub fn request_repaint_after_secs(&self, seconds: f32) {
-    if let Ok(duration) = std::time::Duration::try_from_secs_f32(seconds) {
-      self.request_repaint_after(duration);
+    /// Paint on top of everything else
+    pub fn debug_painter(&self) -> Painter {
+        Self::layer_painter(self, LayerId::debug())
     }
-  }
 
-  /// Request repaint after at most the specified duration elapses.
-  ///
-  /// The backend can chose to repaint sooner, for instance if some other code called
-  /// this method with a lower duration, or if new events arrived.
-  ///
-  /// The function can be multiple times, but only the *smallest* duration will be considered.
-  /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
-  /// after `1 second`
-  ///
-  /// This is primarily useful for applications who would like to save battery by avoiding wasted
-  /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
-  /// and outdated if it is not updated for too long.
-  ///
-  /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
-  /// resources repainting multiple times within the same second (when you have no input),
-  /// just calculate the difference of duration between current time and next second change,
-  /// and call this function, to make sure that you are displaying the latest updated time, but
-  /// not wasting resources on needless repaints within the same second.
-  ///
-  /// ### Quirk:
-  /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
-  /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
-  /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
-  /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
-  /// So, it's not that we are requesting repaint within X duration. We are rather timing out
-  /// during app idle time where we are not receiving any new input events.
-  ///
-  /// This repaints the specified viewport
-  #[track_caller]
-  pub fn request_repaint_after_for(&self, duration: Duration, id: ViewportId) {
-    let cause = RepaintCause::new();
-    self.write(|ctx| ctx.request_repaint_after(duration, id, cause));
-  }
+    /// Print this text next to the cursor at the end of the frame.
+    ///
+    /// If you call this multiple times, the text will be appended.
+    ///
+    /// This only works if compiled with `debug_assertions`.
+    ///
+    /// ```
+    /// # let ctx = egui::Context::default();
+    /// # let state = true;
+    /// ctx.debug_text(format!("State: {state:?}"));
+    /// ```
+    ///
+    /// This is just a convenience for calling [`crate::debug_text::print`].
+    #[track_caller]
+    pub fn debug_text(&self, text: impl Into<WidgetText>) {
+        crate::debug_text::print(self, text);
+    }
 
-  /// Was a repaint requested last frame for the current viewport?
-  #[must_use]
-  pub fn requested_repaint_last_frame(&self) -> bool {
-    self.requested_repaint_last_frame_for(&self.viewport_id())
-  }
+    /// What operating system are we running on?
+    ///
+    /// When compiling natively, this is
+    /// figured out from the `target_os`.
+    ///
+    /// For web, this can be figured out from the user-agent,
+    /// and is done so by [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe).
+    pub fn os(&self) -> OperatingSystem {
+        self.read(|ctx| ctx.os)
+    }
 
-  /// Was a repaint requested last frame for the given viewport?
-  #[must_use]
-  pub fn requested_repaint_last_frame_for(&self, viewport_id: &ViewportId) -> bool {
-    self.read(|ctx| ctx.requested_immediate_repaint_prev_frame(viewport_id))
-  }
+    /// Set the operating system we are running on.
+    ///
+    /// If you are writing wasm-based integration for egui you
+    /// may want to set this based on e.g. the user-agent.
+    pub fn set_os(&self, os: OperatingSystem) {
+        self.write(|ctx| ctx.os = os);
+    }
 
-  /// Has a repaint been requested for the current viewport?
-  #[must_use]
-  pub fn has_requested_repaint(&self) -> bool {
-    self.has_requested_repaint_for(&self.viewport_id())
-  }
+    /// Set the cursor icon.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # let ctx = egui::Context::default();
+    /// ctx.output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
+    /// ```
+    pub fn set_cursor_icon(&self, cursor_icon: CursorIcon) {
+        self.output_mut(|o| o.cursor_icon = cursor_icon);
+    }
 
-  /// Has a repaint been requested for the given viewport?
-  #[must_use]
-  pub fn has_requested_repaint_for(&self, viewport_id: &ViewportId) -> bool {
-    self.read(|ctx| ctx.has_requested_repaint(viewport_id))
-  }
+    /// Open an URL in a browser.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # let ctx = egui::Context::default();
+    /// # let open_url = egui::OpenUrl::same_tab("http://www.example.com");
+    /// ctx.output_mut(|o| o.open_url = Some(open_url));
+    /// ```
+    pub fn open_url(&self, open_url: crate::OpenUrl) {
+        self.output_mut(|o| o.open_url = Some(open_url));
+    }
 
-  /// Why are we repainting?
-  ///
-  /// This can be helpful in debugging why egui is constantly repainting.
-  pub fn repaint_causes(&self) -> Vec<RepaintCause> {
-    self.read(|ctx| ctx.viewports.get(&ctx.viewport_id()).map(|v| v.repaint.prev_causes.clone())).unwrap_or_default()
-  }
+    /// Copy the given text to the system clipboard.
+    ///
+    /// Empty strings are ignored.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # let ctx = egui::Context::default();
+    /// ctx.output_mut(|o| o.copied_text = "Copy this".to_owned());
+    /// ```
+    pub fn copy_text(&self, text: String) {
+        self.output_mut(|o| o.copied_text = text);
+    }
 
-  /// For integrations: this callback will be called when an egui user calls [`Self::request_repaint`] or [`Self::request_repaint_after`].
-  ///
-  /// This lets you wake up a sleeping UI thread.
-  ///
-  /// Note that only one callback can be set. Any new call overrides the previous callback.
-  pub fn set_request_repaint_callback(&self, callback: impl Fn(RequestRepaintInfo) + Send + Sync + 'static) {
-    let callback = Box::new(callback);
-    self.write(|ctx| ctx.request_repaint_callback = Some(callback));
-  }
+    /// Format the given shortcut in a human-readable way (e.g. `Ctrl+Shift+X`).
+    ///
+    /// Can be used to get the text for [`Button::shortcut_text`].
+    pub fn format_shortcut(&self, shortcut: &KeyboardShortcut) -> String {
+        let os = self.os();
+
+        let is_mac = matches!(os, OperatingSystem::Mac | OperatingSystem::IOS);
+
+        let can_show_symbols = || {
+            let ModifierNames {
+                alt,
+                ctrl,
+                shift,
+                mac_cmd,
+                ..
+            } = ModifierNames::SYMBOLS;
+
+            let font_id = TextStyle::Body.resolve(&self.style());
+            self.fonts(|f| {
+                let mut lock = f.lock();
+                let font = lock.fonts.font(&font_id);
+                font.has_glyphs(alt)
+                    && font.has_glyphs(ctrl)
+                    && font.has_glyphs(shift)
+                    && font.has_glyphs(mac_cmd)
+            })
+        };
+
+        if is_mac && can_show_symbols() {
+            shortcut.format(&ModifierNames::SYMBOLS, is_mac)
+        } else {
+            shortcut.format(&ModifierNames::NAMES, is_mac)
+        }
+    }
+
+    /// The current frame number for the current viewport.
+    ///
+    /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
+    ///
+    /// Between calls to [`Self::run`], this is the frame number of the coming frame.
+    pub fn frame_nr(&self) -> u64 {
+        self.frame_nr_for(self.viewport_id())
+    }
+
+    /// The current frame number.
+    ///
+    /// Starts at zero, and is incremented at the end of [`Self::run`] or by [`Self::end_frame`].
+    ///
+    /// Between calls to [`Self::run`], this is the frame number of the coming frame.
+    pub fn frame_nr_for(&self, id: ViewportId) -> u64 {
+        self.read(|ctx| ctx.viewports.get(&id).map_or(0, |v| v.repaint.frame_nr))
+    }
+
+    /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
+    ///
+    /// If this is called at least once in a frame, then there will be another frame right after this.
+    /// Call as many times as you wish, only one repaint will be issued.
+    ///
+    /// To request repaint with a delay, use [`Self::request_repaint_after`].
+    ///
+    /// If called from outside the UI thread, the UI thread will wake up and run,
+    /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
+    /// (this will work on `eframe`).
+    ///
+    /// This will repaint the current viewport.
+    #[track_caller]
+    pub fn request_repaint(&self) {
+        self.request_repaint_of(self.viewport_id());
+    }
+
+    /// Call this if there is need to repaint the UI, i.e. if you are showing an animation.
+    ///
+    /// If this is called at least once in a frame, then there will be another frame right after this.
+    /// Call as many times as you wish, only one repaint will be issued.
+    ///
+    /// To request repaint with a delay, use [`Self::request_repaint_after_for`].
+    ///
+    /// If called from outside the UI thread, the UI thread will wake up and run,
+    /// provided the egui integration has set that up via [`Self::set_request_repaint_callback`]
+    /// (this will work on `eframe`).
+    ///
+    /// This will repaint the specified viewport.
+    #[track_caller]
+    pub fn request_repaint_of(&self, id: ViewportId) {
+        let cause = RepaintCause::new();
+        self.write(|ctx| ctx.request_repaint(id, cause));
+    }
+
+    /// Request repaint after at most the specified duration elapses.
+    ///
+    /// The backend can chose to repaint sooner, for instance if some other code called
+    /// this method with a lower duration, or if new events arrived.
+    ///
+    /// The function can be multiple times, but only the *smallest* duration will be considered.
+    /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
+    /// after `1 second`
+    ///
+    /// This is primarily useful for applications who would like to save battery by avoiding wasted
+    /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
+    /// and outdated if it is not updated for too long.
+    ///
+    /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
+    /// resources repainting multiple times within the same second (when you have no input),
+    /// just calculate the difference of duration between current time and next second change,
+    /// and call this function, to make sure that you are displaying the latest updated time, but
+    /// not wasting resources on needless repaints within the same second.
+    ///
+    /// ### Quirk:
+    /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
+    /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
+    /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
+    /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
+    /// So, it's not that we are requesting repaint within X duration. We are rather timing out
+    /// during app idle time where we are not receiving any new input events.
+    ///
+    /// This repaints the current viewport
+    #[track_caller]
+    pub fn request_repaint_after(&self, duration: Duration) {
+        self.request_repaint_after_for(duration, self.viewport_id());
+    }
+
+    /// Repaint after this many seconds.
+    ///
+    /// See [`Self::request_repaint_after`] for details.
+    #[track_caller]
+    pub fn request_repaint_after_secs(&self, seconds: f32) {
+        if let Ok(duration) = std::time::Duration::try_from_secs_f32(seconds) {
+            self.request_repaint_after(duration);
+        }
+    }
+
+    /// Request repaint after at most the specified duration elapses.
+    ///
+    /// The backend can chose to repaint sooner, for instance if some other code called
+    /// this method with a lower duration, or if new events arrived.
+    ///
+    /// The function can be multiple times, but only the *smallest* duration will be considered.
+    /// So, if the function is called two times with `1 second` and `2 seconds`, egui will repaint
+    /// after `1 second`
+    ///
+    /// This is primarily useful for applications who would like to save battery by avoiding wasted
+    /// redraws when the app is not in focus. But sometimes the GUI of the app might become stale
+    /// and outdated if it is not updated for too long.
+    ///
+    /// Let's say, something like a stopwatch widget that displays the time in seconds. You would waste
+    /// resources repainting multiple times within the same second (when you have no input),
+    /// just calculate the difference of duration between current time and next second change,
+    /// and call this function, to make sure that you are displaying the latest updated time, but
+    /// not wasting resources on needless repaints within the same second.
+    ///
+    /// ### Quirk:
+    /// Duration begins at the next frame. Let's say for example that it's a very inefficient app
+    /// and takes 500 milliseconds per frame at 2 fps. The widget / user might want a repaint in
+    /// next 500 milliseconds. Now, app takes 1000 ms per frame (1 fps) because the backend event
+    /// timeout takes 500 milliseconds AFTER the vsync swap buffer.
+    /// So, it's not that we are requesting repaint within X duration. We are rather timing out
+    /// during app idle time where we are not receiving any new input events.
+    ///
+    /// This repaints the specified viewport
+    #[track_caller]
+    pub fn request_repaint_after_for(&self, duration: Duration, id: ViewportId) {
+        let cause = RepaintCause::new();
+        self.write(|ctx| ctx.request_repaint_after(duration, id, cause));
+    }
+
+    /// Was a repaint requested last frame for the current viewport?
+    #[must_use]
+    pub fn requested_repaint_last_frame(&self) -> bool {
+        self.requested_repaint_last_frame_for(&self.viewport_id())
+    }
+
+    /// Was a repaint requested last frame for the given viewport?
+    #[must_use]
+    pub fn requested_repaint_last_frame_for(&self, viewport_id: &ViewportId) -> bool {
+        self.read(|ctx| ctx.requested_immediate_repaint_prev_frame(viewport_id))
+    }
+
+    /// Has a repaint been requested for the current viewport?
+    #[must_use]
+    pub fn has_requested_repaint(&self) -> bool {
+        self.has_requested_repaint_for(&self.viewport_id())
+    }
+
+    /// Has a repaint been requested for the given viewport?
+    #[must_use]
+    pub fn has_requested_repaint_for(&self, viewport_id: &ViewportId) -> bool {
+        self.read(|ctx| ctx.has_requested_repaint(viewport_id))
+    }
+
+    /// Why are we repainting?
+    ///
+    /// This can be helpful in debugging why egui is constantly repainting.
+    pub fn repaint_causes(&self) -> Vec<RepaintCause> {
+        self.read(|ctx| {
+            ctx.viewports
+                .get(&ctx.viewport_id())
+                .map(|v| v.repaint.prev_causes.clone())
+        })
+        .unwrap_or_default()
+    }
+
+    /// For integrations: this callback will be called when an egui user calls [`Self::request_repaint`] or [`Self::request_repaint_after`].
+    ///
+    /// This lets you wake up a sleeping UI thread.
+    ///
+    /// Note that only one callback can be set. Any new call overrides the previous callback.
+    pub fn set_request_repaint_callback(
+        &self,
+        callback: impl Fn(RequestRepaintInfo) + Send + Sync + 'static,
+    ) {
+        let callback = Box::new(callback);
+        self.write(|ctx| ctx.request_repaint_callback = Some(callback));
+    }
 }
 
 /// Callbacks
 impl Context {
-  /// Call the given callback at the start of each frame
-  /// of each viewport.
-  ///
-  /// This can be used for egui _plugins_.
-  /// See [`crate::debug_text`] for an example.
-  pub fn on_begin_frame(&self, debug_name: &'static str, cb: ContextCallback) {
-    let named_cb = NamedContextCallback { debug_name, callback: cb };
-    self.write(|ctx| ctx.plugins.on_begin_frame.push(named_cb));
-  }
+    /// Call the given callback at the start of each frame
+    /// of each viewport.
+    ///
+    /// This can be used for egui _plugins_.
+    /// See [`crate::debug_text`] for an example.
+    pub fn on_begin_frame(&self, debug_name: &'static str, cb: ContextCallback) {
+        let named_cb = NamedContextCallback {
+            debug_name,
+            callback: cb,
+        };
+        self.write(|ctx| ctx.plugins.on_begin_frame.push(named_cb));
+    }
 
-  /// Call the given callback at the end of each frame
-  /// of each viewport.
-  ///
-  /// This can be used for egui _plugins_.
-  /// See [`crate::debug_text`] for an example.
-  pub fn on_end_frame(&self, debug_name: &'static str, cb: ContextCallback) {
-    let named_cb = NamedContextCallback { debug_name, callback: cb };
-    self.write(|ctx| ctx.plugins.on_end_frame.push(named_cb));
-  }
+    /// Call the given callback at the end of each frame
+    /// of each viewport.
+    ///
+    /// This can be used for egui _plugins_.
+    /// See [`crate::debug_text`] for an example.
+    pub fn on_end_frame(&self, debug_name: &'static str, cb: ContextCallback) {
+        let named_cb = NamedContextCallback {
+            debug_name,
+            callback: cb,
+        };
+        self.write(|ctx| ctx.plugins.on_end_frame.push(named_cb));
+    }
 }
 
 impl Context {
-  /// Tell `egui` which fonts to use.
-  ///
-  /// The default `egui` fonts only support latin and cyrillic alphabets,
-  /// but you can call this to install additional fonts that support e.g. korean characters.
-  ///
-  /// The new fonts will become active at the start of the next frame.
-  pub fn set_fonts(&self, font_definitions: FontDefinitions) {
-    crate::profile_function!();
+    /// Tell `egui` which fonts to use.
+    ///
+    /// The default `egui` fonts only support latin and cyrillic alphabets,
+    /// but you can call this to install additional fonts that support e.g. korean characters.
+    ///
+    /// The new fonts will become active at the start of the next frame.
+    pub fn set_fonts(&self, font_definitions: FontDefinitions) {
+        crate::profile_function!();
 
-    let pixels_per_point = self.pixels_per_point();
+        let pixels_per_point = self.pixels_per_point();
 
-    let mut update_fonts = true;
+        let mut update_fonts = true;
 
-    self.read(|ctx| {
-      if let Some(current_fonts) = ctx.fonts.get(&pixels_per_point.into()) {
-        // NOTE: this comparison is expensive since it checks TTF data for equality
-        if current_fonts.lock().fonts.definitions() == &font_definitions {
-          update_fonts = false; // no need to update
+        self.read(|ctx| {
+            if let Some(current_fonts) = ctx.fonts.get(&pixels_per_point.into()) {
+                // NOTE: this comparison is expensive since it checks TTF data for equality
+                if current_fonts.lock().fonts.definitions() == &font_definitions {
+                    update_fonts = false; // no need to update
+                }
+            }
+        });
+
+        if update_fonts {
+            self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
         }
-      }
-    });
-
-    if update_fonts {
-      self.memory_mut(|mem| mem.new_font_definitions = Some(font_definitions));
     }
-  }
 
-  /// The [`Style`] used by all subsequent windows, panels etc.
-  pub fn style(&self) -> Arc<Style> {
-    self.options(|opt| opt.style.clone())
-  }
-
-  /// Mutate the [`Style`] used by all subsequent windows, panels etc.
-  ///
-  /// Example:
-  /// ```
-  /// # let mut ctx = egui::Context::default();
-  /// ctx.style_mut(|style| {
-  ///     style.spacing.item_spacing = egui::vec2(10.0, 20.0);
-  /// });
-  /// ```
-  pub fn style_mut(&self, mutate_style: impl FnOnce(&mut Style)) {
-    self.options_mut(|opt| mutate_style(std::sync::Arc::make_mut(&mut opt.style)));
-  }
-
-  /// The [`Style`] used by all new windows, panels etc.
-  ///
-  /// You can also change this using [`Self::style_mut`]
-  ///
-  /// You can use [`Ui::style_mut`] to change the style of a single [`Ui`].
-  pub fn set_style(&self, style: impl Into<Arc<Style>>) {
-    self.options_mut(|opt| opt.style = style.into());
-  }
-
-  /// The [`Visuals`] used by all subsequent windows, panels etc.
-  ///
-  /// You can also use [`Ui::visuals_mut`] to change the visuals of a single [`Ui`].
-  ///
-  /// Example:
-  /// ```
-  /// # let mut ctx = egui::Context::default();
-  /// ctx.set_visuals(egui::Visuals::light()); // Switch to light mode
-  /// ```
-  pub fn set_visuals(&self, visuals: crate::Visuals) {
-    self.options_mut(|opt| std::sync::Arc::make_mut(&mut opt.style).visuals = visuals);
-  }
-
-  /// The number of physical pixels for each logical point.
-  ///
-  /// This is calculated as [`Self::zoom_factor`] * [`Self::native_pixels_per_point`]
-  #[inline(always)]
-  pub fn pixels_per_point(&self) -> f32 {
-    self.input(|i| i.pixels_per_point)
-  }
-
-  /// Set the number of physical pixels for each logical point.
-  /// Will become active at the start of the next frame.
-  ///
-  /// This will actually translate to a call to [`Self::set_zoom_factor`].
-  pub fn set_pixels_per_point(&self, pixels_per_point: f32) {
-    if pixels_per_point != self.pixels_per_point() {
-      self.set_zoom_factor(pixels_per_point / self.native_pixels_per_point().unwrap_or(1.0));
+    /// The [`Style`] used by all subsequent windows, panels etc.
+    pub fn style(&self) -> Arc<Style> {
+        self.options(|opt| opt.style.clone())
     }
-  }
 
-  /// The number of physical pixels for each logical point on this monitor.
-  ///
-  /// This is given as input to egui via [`ViewportInfo::native_pixels_per_point`]
-  /// and cannot be changed.
-  #[inline(always)]
-  pub fn native_pixels_per_point(&self) -> Option<f32> {
-    self.input(|i| i.viewport().native_pixels_per_point)
-  }
+    /// Mutate the [`Style`] used by all subsequent windows, panels etc.
+    ///
+    /// Example:
+    /// ```
+    /// # let mut ctx = egui::Context::default();
+    /// ctx.style_mut(|style| {
+    ///     style.spacing.item_spacing = egui::vec2(10.0, 20.0);
+    /// });
+    /// ```
+    pub fn style_mut(&self, mutate_style: impl FnOnce(&mut Style)) {
+        self.options_mut(|opt| mutate_style(std::sync::Arc::make_mut(&mut opt.style)));
+    }
 
-  /// Global zoom factor of the UI.
-  ///
-  /// This is used to calculate the `pixels_per_point`
-  /// for the UI as `pixels_per_point = zoom_factor * native_pixels_per_point`.
-  ///
-  /// The default is 1.0.
-  /// Make larger to make everything larger.
-  #[inline(always)]
-  pub fn zoom_factor(&self) -> f32 {
-    self.options(|o| o.zoom_factor)
-  }
+    /// The [`Style`] used by all new windows, panels etc.
+    ///
+    /// You can also change this using [`Self::style_mut`]
+    ///
+    /// You can use [`Ui::style_mut`] to change the style of a single [`Ui`].
+    pub fn set_style(&self, style: impl Into<Arc<Style>>) {
+        self.options_mut(|opt| opt.style = style.into());
+    }
 
-  /// Sets zoom factor of the UI.
-  /// Will become active at the start of the next frame.
-  ///
-  /// Note that calling this will not update [`Self::zoom_factor`] until the end of the frame.
-  ///
-  /// This is used to calculate the `pixels_per_point`
-  /// for the UI as `pixels_per_point = zoom_fator * native_pixels_per_point`.
-  ///
-  /// The default is 1.0.
-  /// Make larger to make everything larger.
-  ///
-  /// It is better to call this than modifying
-  /// [`Options::zoom_factor`].
-  #[inline(always)]
-  pub fn set_zoom_factor(&self, zoom_factor: f32) {
-    let cause = RepaintCause::new();
-    self.write(|ctx| {
-      if ctx.memory.options.zoom_factor != zoom_factor {
-        ctx.new_zoom_factor = Some(zoom_factor);
-        for viewport_id in ctx.all_viewport_ids() {
-          ctx.request_repaint(viewport_id, cause.clone());
+    /// The [`Visuals`] used by all subsequent windows, panels etc.
+    ///
+    /// You can also use [`Ui::visuals_mut`] to change the visuals of a single [`Ui`].
+    ///
+    /// Example:
+    /// ```
+    /// # let mut ctx = egui::Context::default();
+    /// ctx.set_visuals(egui::Visuals::light()); // Switch to light mode
+    /// ```
+    pub fn set_visuals(&self, visuals: crate::Visuals) {
+        self.options_mut(|opt| std::sync::Arc::make_mut(&mut opt.style).visuals = visuals);
+    }
+
+    /// The number of physical pixels for each logical point.
+    ///
+    /// This is calculated as [`Self::zoom_factor`] * [`Self::native_pixels_per_point`]
+    #[inline(always)]
+    pub fn pixels_per_point(&self) -> f32 {
+        self.input(|i| i.pixels_per_point)
+    }
+
+    /// Set the number of physical pixels for each logical point.
+    /// Will become active at the start of the next frame.
+    ///
+    /// This will actually translate to a call to [`Self::set_zoom_factor`].
+    pub fn set_pixels_per_point(&self, pixels_per_point: f32) {
+        if pixels_per_point != self.pixels_per_point() {
+            self.set_zoom_factor(pixels_per_point / self.native_pixels_per_point().unwrap_or(1.0));
         }
-      }
-    });
-  }
+    }
 
-  /// Useful for pixel-perfect rendering
-  #[inline]
-  pub fn round_to_pixel(&self, point: f32) -> f32 {
-    let pixels_per_point = self.pixels_per_point();
-    (point * pixels_per_point).round() / pixels_per_point
-  }
+    /// The number of physical pixels for each logical point on this monitor.
+    ///
+    /// This is given as input to egui via [`ViewportInfo::native_pixels_per_point`]
+    /// and cannot be changed.
+    #[inline(always)]
+    pub fn native_pixels_per_point(&self) -> Option<f32> {
+        self.input(|i| i.viewport().native_pixels_per_point)
+    }
 
-  /// Useful for pixel-perfect rendering
-  #[inline]
-  pub fn round_pos_to_pixels(&self, pos: Pos2) -> Pos2 {
-    pos2(self.round_to_pixel(pos.x), self.round_to_pixel(pos.y))
-  }
+    /// Global zoom factor of the UI.
+    ///
+    /// This is used to calculate the `pixels_per_point`
+    /// for the UI as `pixels_per_point = zoom_factor * native_pixels_per_point`.
+    ///
+    /// The default is 1.0.
+    /// Make larger to make everything larger.
+    #[inline(always)]
+    pub fn zoom_factor(&self) -> f32 {
+        self.options(|o| o.zoom_factor)
+    }
 
-  /// Useful for pixel-perfect rendering
-  #[inline]
-  pub fn round_vec_to_pixels(&self, vec: Vec2) -> Vec2 {
-    vec2(self.round_to_pixel(vec.x), self.round_to_pixel(vec.y))
-  }
+    /// Sets zoom factor of the UI.
+    /// Will become active at the start of the next frame.
+    ///
+    /// Note that calling this will not update [`Self::zoom_factor`] until the end of the frame.
+    ///
+    /// This is used to calculate the `pixels_per_point`
+    /// for the UI as `pixels_per_point = zoom_fator * native_pixels_per_point`.
+    ///
+    /// The default is 1.0.
+    /// Make larger to make everything larger.
+    ///
+    /// It is better to call this than modifying
+    /// [`Options::zoom_factor`].
+    #[inline(always)]
+    pub fn set_zoom_factor(&self, zoom_factor: f32) {
+        let cause = RepaintCause::new();
+        self.write(|ctx| {
+            if ctx.memory.options.zoom_factor != zoom_factor {
+                ctx.new_zoom_factor = Some(zoom_factor);
+                for viewport_id in ctx.all_viewport_ids() {
+                    ctx.request_repaint(viewport_id, cause.clone());
+                }
+            }
+        });
+    }
 
-  /// Useful for pixel-perfect rendering
-  #[inline]
-  pub fn round_rect_to_pixels(&self, rect: Rect) -> Rect {
-    Rect { min: self.round_pos_to_pixels(rect.min), max: self.round_pos_to_pixels(rect.max) }
-  }
+    /// Useful for pixel-perfect rendering of lines
+    #[inline]
+    pub(crate) fn round_to_pixel_center(&self, point: f32) -> f32 {
+        let pixels_per_point = self.pixels_per_point();
+        ((point * pixels_per_point - 0.5).round() + 0.5) / pixels_per_point
+    }
 
-  /// Allocate a texture.
-  ///
-  /// This is for advanced users.
-  /// Most users should use [`crate::Ui::image`] or [`Self::try_load_texture`]
-  /// instead.
-  ///
-  /// In order to display an image you must convert it to a texture using this function.
-  /// The function will hand over the image data to the egui backend, which will
-  /// upload it to the GPU.
-  ///
-  /// ⚠️ Make sure to only call this ONCE for each image, i.e. NOT in your main GUI code.
-  /// The call is NOT immediate safe.
-  ///
-  /// The given name can be useful for later debugging, and will be visible if you call [`Self::texture_ui`].
-  ///
-  /// For how to load an image, see [`ImageData`] and [`ColorImage::from_rgba_unmultiplied`].
-  ///
-  /// ```
-  /// struct MyImage {
-  ///     texture: Option<egui::TextureHandle>,
-  /// }
-  ///
-  /// impl MyImage {
-  ///     fn ui(&mut self, ui: &mut egui::Ui) {
-  ///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
-  ///             // Load the texture only once.
-  ///             ui.ctx().load_texture(
-  ///                 "my-image",
-  ///                 egui::ColorImage::example(),
-  ///                 Default::default()
-  ///             )
-  ///         });
-  ///
-  ///         // Show the image:
-  ///         ui.image((texture.id(), texture.size_vec2()));
-  ///     }
-  /// }
-  /// ```
-  ///
-  /// See also [`crate::ImageData`], [`crate::Ui::image`] and [`crate::Image`].
-  pub fn load_texture(
-    &self,
-    name: impl Into<String>,
-    image: impl Into<ImageData>,
-    options: TextureOptions,
-  ) -> TextureHandle {
-    let name = name.into();
-    let image = image.into();
-    let max_texture_side = self.input(|i| i.max_texture_side);
-    debug_assert!(
-      image.width() <= max_texture_side && image.height() <= max_texture_side,
-      "Texture {:?} has size {}x{}, but the maximum texture side is {}",
-      name,
-      image.width(),
-      image.height(),
-      max_texture_side
-    );
-    let tex_mngr = self.tex_manager();
-    let tex_id = tex_mngr.write().alloc(name, image, options);
-    TextureHandle::new(tex_mngr, tex_id)
-  }
+    /// Useful for pixel-perfect rendering of lines
+    #[inline]
+    pub(crate) fn round_pos_to_pixel_center(&self, point: Pos2) -> Pos2 {
+        pos2(
+            self.round_to_pixel_center(point.x),
+            self.round_to_pixel_center(point.y),
+        )
+    }
 
-  /// Low-level texture manager.
-  ///
-  /// In general it is easier to use [`Self::load_texture`] and [`TextureHandle`].
-  ///
-  /// You can show stats about the allocated textures using [`Self::texture_ui`].
-  pub fn tex_manager(&self) -> Arc<RwLock<epaint::textures::TextureManager>> {
-    self.read(|ctx| ctx.tex_manager.0.clone())
-  }
+    /// Useful for pixel-perfect rendering of filled shapes
+    #[inline]
+    pub fn round_to_pixel(&self, point: f32) -> f32 {
+        let pixels_per_point = self.pixels_per_point();
+        (point * pixels_per_point).round() / pixels_per_point
+    }
 
-  // ---------------------------------------------------------------------
+    /// Useful for pixel-perfect rendering of filled shapes
+    #[inline]
+    pub fn round_pos_to_pixels(&self, pos: Pos2) -> Pos2 {
+        pos2(self.round_to_pixel(pos.x), self.round_to_pixel(pos.y))
+    }
 
-  /// Constrain the position of a window/area so it fits within the provided boundary.
-  pub fn constrain_window_rect_to_area(&self, window: Rect, area: Rect) -> Rect {
-    let mut pos = window.min;
+    /// Useful for pixel-perfect rendering of filled shapes
+    #[inline]
+    pub fn round_vec_to_pixels(&self, vec: Vec2) -> Vec2 {
+        vec2(self.round_to_pixel(vec.x), self.round_to_pixel(vec.y))
+    }
 
-    // Constrain to screen, unless window is too large to fit:
-    let margin_x = (window.width() - area.width()).at_least(0.0);
-    let margin_y = (window.height() - area.height()).at_least(0.0);
+    /// Useful for pixel-perfect rendering of filled shapes
+    #[inline]
+    pub fn round_rect_to_pixels(&self, rect: Rect) -> Rect {
+        Rect {
+            min: self.round_pos_to_pixels(rect.min),
+            max: self.round_pos_to_pixels(rect.max),
+        }
+    }
 
-    pos.x = pos.x.at_most(area.right() + margin_x - window.width()); // move left if needed
-    pos.x = pos.x.at_least(area.left() - margin_x); // move right if needed
-    pos.y = pos.y.at_most(area.bottom() + margin_y - window.height()); // move right if needed
-    pos.y = pos.y.at_least(area.top() - margin_y); // move down if needed
+    /// Allocate a texture.
+    ///
+    /// This is for advanced users.
+    /// Most users should use [`crate::Ui::image`] or [`Self::try_load_texture`]
+    /// instead.
+    ///
+    /// In order to display an image you must convert it to a texture using this function.
+    /// The function will hand over the image data to the egui backend, which will
+    /// upload it to the GPU.
+    ///
+    /// ⚠️ Make sure to only call this ONCE for each image, i.e. NOT in your main GUI code.
+    /// The call is NOT immediate safe.
+    ///
+    /// The given name can be useful for later debugging, and will be visible if you call [`Self::texture_ui`].
+    ///
+    /// For how to load an image, see [`ImageData`] and [`ColorImage::from_rgba_unmultiplied`].
+    ///
+    /// ```
+    /// struct MyImage {
+    ///     texture: Option<egui::TextureHandle>,
+    /// }
+    ///
+    /// impl MyImage {
+    ///     fn ui(&mut self, ui: &mut egui::Ui) {
+    ///         let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
+    ///             // Load the texture only once.
+    ///             ui.ctx().load_texture(
+    ///                 "my-image",
+    ///                 egui::ColorImage::example(),
+    ///                 Default::default()
+    ///             )
+    ///         });
+    ///
+    ///         // Show the image:
+    ///         ui.image((texture.id(), texture.size_vec2()));
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// See also [`crate::ImageData`], [`crate::Ui::image`] and [`crate::Image`].
+    pub fn load_texture(
+        &self,
+        name: impl Into<String>,
+        image: impl Into<ImageData>,
+        options: TextureOptions,
+    ) -> TextureHandle {
+        let name = name.into();
+        let image = image.into();
+        let max_texture_side = self.input(|i| i.max_texture_side);
+        debug_assert!(
+            image.width() <= max_texture_side && image.height() <= max_texture_side,
+            "Texture {:?} has size {}x{}, but the maximum texture side is {}",
+            name,
+            image.width(),
+            image.height(),
+            max_texture_side
+        );
+        let tex_mngr = self.tex_manager();
+        let tex_id = tex_mngr.write().alloc(name, image, options);
+        TextureHandle::new(tex_mngr, tex_id)
+    }
 
-    pos = self.round_pos_to_pixels(pos);
+    /// Low-level texture manager.
+    ///
+    /// In general it is easier to use [`Self::load_texture`] and [`TextureHandle`].
+    ///
+    /// You can show stats about the allocated textures using [`Self::texture_ui`].
+    pub fn tex_manager(&self) -> Arc<RwLock<epaint::textures::TextureManager>> {
+        self.read(|ctx| ctx.tex_manager.0.clone())
+    }
 
-    Rect::from_min_size(pos, window.size())
-  }
+    // ---------------------------------------------------------------------
+
+    /// Constrain the position of a window/area so it fits within the provided boundary.
+    pub fn constrain_window_rect_to_area(&self, window: Rect, area: Rect) -> Rect {
+        let mut pos = window.min;
+
+        // Constrain to screen, unless window is too large to fit:
+        let margin_x = (window.width() - area.width()).at_least(0.0);
+        let margin_y = (window.height() - area.height()).at_least(0.0);
+
+        pos.x = pos.x.at_most(area.right() + margin_x - window.width()); // move left if needed
+        pos.x = pos.x.at_least(area.left() - margin_x); // move right if needed
+        pos.y = pos.y.at_most(area.bottom() + margin_y - window.height()); // move right if needed
+        pos.y = pos.y.at_least(area.top() - margin_y); // move down if needed
+
+        pos = self.round_pos_to_pixels(pos);
+
+        Rect::from_min_size(pos, window.size())
+    }
 }
 
 impl Context {
-  /// Call at the end of each frame.
-  #[must_use]
-  pub fn end_frame(&self) -> FullOutput {
-    crate::profile_function!();
+    /// Call at the end of each frame.
+    #[must_use]
+    pub fn end_frame(&self) -> FullOutput {
+        crate::profile_function!();
 
-    if self.options(|o| o.zoom_with_keyboard) {
-      crate::gui_zoom::zoom_with_keyboard(self);
+        if self.options(|o| o.zoom_with_keyboard) {
+            crate::gui_zoom::zoom_with_keyboard(self);
+        }
+
+        // Plugins run just before the frame ends.
+        self.read(|ctx| ctx.plugins.clone()).on_end_frame(self);
+
+        #[cfg(debug_assertions)]
+        self.debug_painting();
+
+        self.write(|ctx| ctx.end_frame())
     }
 
-    // Plugins run just before the frame ends.
-    self.read(|ctx| ctx.plugins.clone()).on_end_frame(self);
-
+    /// Called at the end of the frame.
     #[cfg(debug_assertions)]
-    self.debug_painting();
-
-    self.write(|ctx| ctx.end_frame())
-  }
-
-  /// Called at the end of the frame.
-  #[cfg(debug_assertions)]
-  fn debug_painting(&self) {
-    let paint_widget = |widget: &WidgetRect, text: &str, color: Color32| {
-      let rect = widget.interact_rect;
-      if rect.is_positive() {
-        let painter = Painter::new(self.clone(), widget.layer_id, Rect::EVERYTHING);
-        painter.debug_rect(rect, color, text);
-      }
-    };
-
-    let paint_widget_id = |id: Id, text: &str, color: Color32| {
-      if let Some(widget) = self.write(|ctx| ctx.viewport().this_frame.widgets.get(id).copied()) {
-        paint_widget(&widget, text, color);
-      }
-    };
-
-    if self.style().debug.show_interactive_widgets {
-      // Show all interactive widgets:
-      let rects = self.write(|ctx| ctx.viewport().this_frame.widgets.clone());
-      for (layer_id, rects) in rects.layers() {
-        let painter = Painter::new(self.clone(), *layer_id, Rect::EVERYTHING);
-        for rect in rects {
-          if rect.sense.interactive() {
-            let (color, text) = if rect.sense.click && rect.sense.drag {
-              (Color32::from_rgb(0x88, 0, 0x88), "click+drag")
-            } else if rect.sense.click {
-              (Color32::from_rgb(0x88, 0, 0), "click")
-            } else if rect.sense.drag {
-              (Color32::from_rgb(0, 0, 0x88), "drag")
-            } else {
-              // unreachable since we only show interactive
-              (Color32::from_rgb(0, 0, 0x88), "hover")
-            };
-            painter.debug_rect(rect.interact_rect, color, text);
-          }
-        }
-      }
-
-      // Show the ones actually interacted with:
-      {
-        let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
-        let InteractionSnapshot {
-          clicked,
-          long_touched: _,
-          drag_started: _,
-          dragged,
-          drag_stopped: _,
-          contains_pointer,
-          hovered,
-        } = interact_widgets;
-
-        if true {
-          for &id in &contains_pointer {
-            paint_widget_id(id, "contains_pointer", Color32::BLUE);
-          }
-
-          let widget_rects = self.write(|w| w.viewport().this_frame.widgets.clone());
-
-          let mut contains_pointer: Vec<Id> = contains_pointer.iter().copied().collect();
-          contains_pointer.sort_by_key(|&id| {
-            widget_rects.order(id).map(|(layer_id, order_in_layer)| (layer_id.order, order_in_layer))
-          });
-
-          let mut debug_text = "Widgets in order:\n".to_owned();
-          for id in contains_pointer {
-            let mut widget_text = format!("{id:?}");
-            if let Some(rect) = widget_rects.get(id) {
-              widget_text += &format!(" {:?} {:?}", rect.rect, rect.sense);
+    fn debug_painting(&self) {
+        let paint_widget = |widget: &WidgetRect, text: &str, color: Color32| {
+            let rect = widget.interact_rect;
+            if rect.is_positive() {
+                let painter = Painter::new(self.clone(), widget.layer_id, Rect::EVERYTHING);
+                painter.debug_rect(rect, color, text);
             }
-            if let Some(info) = widget_rects.info(id) {
-              widget_text += &format!(" {info:?}");
+        };
+
+        let paint_widget_id = |id: Id, text: &str, color: Color32| {
+            if let Some(widget) =
+                self.write(|ctx| ctx.viewport().this_frame.widgets.get(id).copied())
+            {
+                paint_widget(&widget, text, color);
             }
-            debug_text += &format!("{widget_text}\n");
-          }
-          self.debug_text(debug_text);
-        }
-        if true {
-          for widget in hovered {
-            paint_widget_id(widget, "hovered", Color32::WHITE);
-          }
-        }
-        for &widget in &clicked {
-          paint_widget_id(widget, "clicked", Color32::RED);
-        }
-        for &widget in &dragged {
-          paint_widget_id(widget, "dragged", Color32::GREEN);
-        }
-      }
-    }
+        };
 
-    if self.style().debug.show_widget_hits {
-      let hits = self.write(|ctx| ctx.viewport().hits.clone());
-      let WidgetHits { contains_pointer, click, drag } = hits;
+        if self.style().debug.show_interactive_widgets {
+            // Show all interactive widgets:
+            let rects = self.write(|ctx| ctx.viewport().this_frame.widgets.clone());
+            for (layer_id, rects) in rects.layers() {
+                let painter = Painter::new(self.clone(), *layer_id, Rect::EVERYTHING);
+                for rect in rects {
+                    if rect.sense.interactive() {
+                        let (color, text) = if rect.sense.click && rect.sense.drag {
+                            (Color32::from_rgb(0x88, 0, 0x88), "click+drag")
+                        } else if rect.sense.click {
+                            (Color32::from_rgb(0x88, 0, 0), "click")
+                        } else if rect.sense.drag {
+                            (Color32::from_rgb(0, 0, 0x88), "drag")
+                        } else {
+                            // unreachable since we only show interactive
+                            (Color32::from_rgb(0, 0, 0x88), "hover")
+                        };
+                        painter.debug_rect(rect.interact_rect, color, text);
+                    }
+                }
+            }
 
-      if true {
-        for widget in &contains_pointer {
-          paint_widget(widget, "contains_pointer", Color32::BLUE);
+            // Show the ones actually interacted with:
+            {
+                let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
+                let InteractionSnapshot {
+                    clicked,
+                    long_touched: _,
+                    drag_started: _,
+                    dragged,
+                    drag_stopped: _,
+                    contains_pointer,
+                    hovered,
+                } = interact_widgets;
+
+                if true {
+                    for &id in &contains_pointer {
+                        paint_widget_id(id, "contains_pointer", Color32::BLUE);
+                    }
+
+                    let widget_rects = self.write(|w| w.viewport().this_frame.widgets.clone());
+
+                    let mut contains_pointer: Vec<Id> = contains_pointer.iter().copied().collect();
+                    contains_pointer.sort_by_key(|&id| {
+                        widget_rects
+                            .order(id)
+                            .map(|(layer_id, order_in_layer)| (layer_id.order, order_in_layer))
+                    });
+
+                    let mut debug_text = "Widgets in order:\n".to_owned();
+                    for id in contains_pointer {
+                        let mut widget_text = format!("{id:?}");
+                        if let Some(rect) = widget_rects.get(id) {
+                            widget_text += &format!(" {:?} {:?}", rect.rect, rect.sense);
+                        }
+                        if let Some(info) = widget_rects.info(id) {
+                            widget_text += &format!(" {info:?}");
+                        }
+                        debug_text += &format!("{widget_text}\n");
+                    }
+                    self.debug_text(debug_text);
+                }
+                if true {
+                    for widget in hovered {
+                        paint_widget_id(widget, "hovered", Color32::WHITE);
+                    }
+                }
+                for &widget in &clicked {
+                    paint_widget_id(widget, "clicked", Color32::RED);
+                }
+                for &widget in &dragged {
+                    paint_widget_id(widget, "dragged", Color32::GREEN);
+                }
+            }
         }
-      }
-      for widget in &click {
-        paint_widget(widget, "click", Color32::RED);
-      }
-      for widget in &drag {
-        paint_widget(widget, "drag", Color32::GREEN);
-      }
-    }
 
-    if let Some(debug_rect) = self.frame_state_mut(|fs| fs.debug_rect.take()) {
-      debug_rect.paint(&self.debug_painter());
+        if self.style().debug.show_widget_hits {
+            let hits = self.write(|ctx| ctx.viewport().hits.clone());
+            let WidgetHits {
+                contains_pointer,
+                click,
+                drag,
+            } = hits;
+
+            if true {
+                for widget in &contains_pointer {
+                    paint_widget(widget, "contains_pointer", Color32::BLUE);
+                }
+            }
+            for widget in &click {
+                paint_widget(widget, "click", Color32::RED);
+            }
+            for widget in &drag {
+                paint_widget(widget, "drag", Color32::GREEN);
+            }
+        }
+
+        if let Some(debug_rect) = self.frame_state_mut(|fs| fs.debug_rect.take()) {
+            debug_rect.paint(&self.debug_painter());
+        }
     }
-  }
 }
 
 impl ContextImpl {
-  fn end_frame(&mut self) -> FullOutput {
-    let ended_viewport_id = self.viewport_id();
-    let viewport = self.viewports.entry(ended_viewport_id).or_default();
-    let pixels_per_point = viewport.input.pixels_per_point;
+    fn end_frame(&mut self) -> FullOutput {
+        let ended_viewport_id = self.viewport_id();
+        let viewport = self.viewports.entry(ended_viewport_id).or_default();
+        let pixels_per_point = viewport.input.pixels_per_point;
 
-    viewport.repaint.frame_nr += 1;
+        viewport.repaint.frame_nr += 1;
 
-    self.memory.end_frame(&viewport.this_frame.used_ids);
+        self.memory.end_frame(&viewport.this_frame.used_ids);
 
-    if let Some(fonts) = self.fonts.get(&pixels_per_point.into()) {
-      let tex_mngr = &mut self.tex_manager.0.write();
-      if let Some(font_image_delta) = fonts.font_image_delta() {
-        // A partial font atlas update, e.g. a new glyph has been entered.
-        tex_mngr.set(TextureId::default(), font_image_delta);
-      }
+        if let Some(fonts) = self.fonts.get(&pixels_per_point.into()) {
+            let tex_mngr = &mut self.tex_manager.0.write();
+            if let Some(font_image_delta) = fonts.font_image_delta() {
+                // A partial font atlas update, e.g. a new glyph has been entered.
+                tex_mngr.set(TextureId::default(), font_image_delta);
+            }
 
-      if 1 < self.fonts.len() {
-        // We have multiple different `pixels_per_point`,
-        // e.g. because we have many viewports spread across
-        // monitors with different DPI scaling.
-        // All viewports share the same texture namespace and renderer,
-        // so the all use `TextureId::default()` for the font texture.
-        // This is a problem.
-        // We solve this with a hack: we always upload the full font atlas
-        // every frame, for all viewports.
-        // This ensures it is up-to-date, solving
-        // https://github.com/emilk/egui/issues/3664
-        // at the cost of a lot of performance.
-        // (This will override any smaller delta that was uploaded above.)
-        crate::profile_scope!("full_font_atlas_update");
-        let full_delta = ImageDelta::full(fonts.image(), TextureAtlas::texture_options());
-        tex_mngr.set(TextureId::default(), full_delta);
-      }
-    }
-
-    // Inform the backend of all textures that have been updated (including font atlas).
-    let textures_delta = self.tex_manager.0.write().take_delta();
-
-    #[cfg_attr(not(feature = "accesskit"), allow(unused_mut))]
-    let mut platform_output: PlatformOutput = std::mem::take(&mut viewport.output);
-
-    #[cfg(feature = "accesskit")]
-    {
-      crate::profile_scope!("accesskit");
-      let state = viewport.this_frame.accesskit_state.take();
-      if let Some(state) = state {
-        let root_id = crate::accesskit_root_id().accesskit_id();
-        let nodes = {
-          state
-            .node_builders
-            .into_iter()
-            .map(|(id, builder)| (id.accesskit_id(), builder.build(&mut self.accesskit_node_classes)))
-            .collect()
-        };
-        let focus_id = self.memory.focused().map_or(root_id, |id| id.accesskit_id());
-        platform_output.accesskit_update =
-          Some(accesskit::TreeUpdate { nodes, tree: Some(accesskit::Tree::new(root_id)), focus: focus_id });
-      }
-    }
-
-    let shapes = viewport.graphics.drain(self.memory.areas().order(), &self.memory.layer_transforms);
-
-    let mut repaint_needed = false;
-
-    if self.memory.options.repaint_on_widget_change {
-      crate::profile_function!("compare-widget-rects");
-      if viewport.prev_frame.widgets != viewport.this_frame.widgets {
-        repaint_needed = true; // Some widget has moved
-      }
-    }
-
-    std::mem::swap(&mut viewport.prev_frame, &mut viewport.this_frame);
-
-    if repaint_needed {
-      self.request_repaint(ended_viewport_id, RepaintCause::new());
-    } else if let Some(delay) = viewport.input.wants_repaint_after() {
-      self.request_repaint_after(delay, ended_viewport_id, RepaintCause::new());
-    }
-
-    //  -------------------
-
-    let all_viewport_ids = self.all_viewport_ids();
-
-    self.last_viewport = ended_viewport_id;
-
-    self.viewports.retain(|&id, viewport| {
-      let parent = *self.viewport_parents.entry(id).or_default();
-
-      if !all_viewport_ids.contains(&parent) {
-        #[cfg(feature = "log")]
-        log::debug!("Removing viewport {:?} ({:?}): the parent is gone", id, viewport.builder.title);
-
-        return false;
-      }
-
-      let is_our_child = parent == ended_viewport_id && id != ViewportId::ROOT;
-      if is_our_child {
-        if !viewport.used {
-          #[cfg(feature = "log")]
-          log::debug!("Removing viewport {:?} ({:?}): it was never used this frame", id, viewport.builder.title);
-
-          return false; // Only keep children that have been updated this frame
+            if 1 < self.fonts.len() {
+                // We have multiple different `pixels_per_point`,
+                // e.g. because we have many viewports spread across
+                // monitors with different DPI scaling.
+                // All viewports share the same texture namespace and renderer,
+                // so the all use `TextureId::default()` for the font texture.
+                // This is a problem.
+                // We solve this with a hack: we always upload the full font atlas
+                // every frame, for all viewports.
+                // This ensures it is up-to-date, solving
+                // https://github.com/emilk/egui/issues/3664
+                // at the cost of a lot of performance.
+                // (This will override any smaller delta that was uploaded above.)
+                crate::profile_scope!("full_font_atlas_update");
+                let full_delta = ImageDelta::full(fonts.image(), TextureAtlas::texture_options());
+                tex_mngr.set(TextureId::default(), full_delta);
+            }
         }
 
-        viewport.used = false; // reset so we can check again next frame
-      }
+        // Inform the backend of all textures that have been updated (including font atlas).
+        let textures_delta = self.tex_manager.0.write().take_delta();
 
-      true
-    });
+        #[cfg_attr(not(feature = "accesskit"), allow(unused_mut))]
+        let mut platform_output: PlatformOutput = std::mem::take(&mut viewport.output);
 
-    // If we are an immediate viewport, this will resume the previous viewport.
-    self.viewport_stack.pop();
+        #[cfg(feature = "accesskit")]
+        {
+            crate::profile_scope!("accesskit");
+            let state = viewport.this_frame.accesskit_state.take();
+            if let Some(state) = state {
+                let root_id = crate::accesskit_root_id().accesskit_id();
+                let nodes = {
+                    state
+                        .node_builders
+                        .into_iter()
+                        .map(|(id, builder)| {
+                            (
+                                id.accesskit_id(),
+                                builder.build(&mut self.accesskit_node_classes),
+                            )
+                        })
+                        .collect()
+                };
+                let focus_id = self
+                    .memory
+                    .focused()
+                    .map_or(root_id, |id| id.accesskit_id());
+                platform_output.accesskit_update = Some(accesskit::TreeUpdate {
+                    nodes,
+                    tree: Some(accesskit::Tree::new(root_id)),
+                    focus: focus_id,
+                });
+            }
+        }
 
-    // The last viewport is not necessarily the root viewport,
-    // just the top _immediate_ viewport.
-    let is_last = self.viewport_stack.is_empty();
+        let shapes = viewport
+            .graphics
+            .drain(self.memory.areas().order(), &self.memory.layer_transforms);
 
-    let viewport_output = self
-      .viewports
-      .iter_mut()
-      .map(|(&id, viewport)| {
-        let parent = *self.viewport_parents.entry(id).or_default();
-        let commands = if is_last {
-          // Let the primary immediate viewport handle the commands of its children too.
-          // This can make things easier for the backend, as otherwise we may get commands
-          // that affect a viewport while its egui logic is running.
-          std::mem::take(&mut viewport.commands)
+        let mut repaint_needed = false;
+
+        if self.memory.options.repaint_on_widget_change {
+            crate::profile_function!("compare-widget-rects");
+            if viewport.prev_frame.widgets != viewport.this_frame.widgets {
+                repaint_needed = true; // Some widget has moved
+            }
+        }
+
+        std::mem::swap(&mut viewport.prev_frame, &mut viewport.this_frame);
+
+        if repaint_needed {
+            self.request_repaint(ended_viewport_id, RepaintCause::new());
+        } else if let Some(delay) = viewport.input.wants_repaint_after() {
+            self.request_repaint_after(delay, ended_viewport_id, RepaintCause::new());
+        }
+
+        //  -------------------
+
+        let all_viewport_ids = self.all_viewport_ids();
+
+        self.last_viewport = ended_viewport_id;
+
+        self.viewports.retain(|&id, viewport| {
+            let parent = *self.viewport_parents.entry(id).or_default();
+
+            if !all_viewport_ids.contains(&parent) {
+                #[cfg(feature = "log")]
+                log::debug!(
+                    "Removing viewport {:?} ({:?}): the parent is gone",
+                    id,
+                    viewport.builder.title
+                );
+
+                return false;
+            }
+
+            let is_our_child = parent == ended_viewport_id && id != ViewportId::ROOT;
+            if is_our_child {
+                if !viewport.used {
+                    #[cfg(feature = "log")]
+                    log::debug!(
+                        "Removing viewport {:?} ({:?}): it was never used this frame",
+                        id,
+                        viewport.builder.title
+                    );
+
+                    return false; // Only keep children that have been updated this frame
+                }
+
+                viewport.used = false; // reset so we can check again next frame
+            }
+
+            true
+        });
+
+        // If we are an immediate viewport, this will resume the previous viewport.
+        self.viewport_stack.pop();
+
+        // The last viewport is not necessarily the root viewport,
+        // just the top _immediate_ viewport.
+        let is_last = self.viewport_stack.is_empty();
+
+        let viewport_output = self
+            .viewports
+            .iter_mut()
+            .map(|(&id, viewport)| {
+                let parent = *self.viewport_parents.entry(id).or_default();
+                let commands = if is_last {
+                    // Let the primary immediate viewport handle the commands of its children too.
+                    // This can make things easier for the backend, as otherwise we may get commands
+                    // that affect a viewport while its egui logic is running.
+                    std::mem::take(&mut viewport.commands)
+                } else {
+                    vec![]
+                };
+
+                (
+                    id,
+                    ViewportOutput {
+                        parent,
+                        class: viewport.class,
+                        builder: viewport.builder.clone(),
+                        viewport_ui_cb: viewport.viewport_ui_cb.clone(),
+                        commands,
+                        repaint_delay: viewport.repaint.repaint_delay,
+                    },
+                )
+            })
+            .collect();
+
+        if is_last {
+            // Remove dead viewports:
+            self.viewports.retain(|id, _| all_viewport_ids.contains(id));
+            self.viewport_parents
+                .retain(|id, _| all_viewport_ids.contains(id));
         } else {
-          vec![]
-        };
+            let viewport_id = self.viewport_id();
+            self.memory.set_viewport_id(viewport_id);
+        }
 
-        (
-          id,
-          ViewportOutput {
-            parent,
-            class: viewport.class,
-            builder: viewport.builder.clone(),
-            viewport_ui_cb: viewport.viewport_ui_cb.clone(),
-            commands,
-            repaint_delay: viewport.repaint.repaint_delay,
-          },
-        )
-      })
-      .collect();
+        let active_pixels_per_point: std::collections::BTreeSet<OrderedFloat<f32>> = self
+            .viewports
+            .values()
+            .map(|v| v.input.pixels_per_point.into())
+            .collect();
+        self.fonts.retain(|pixels_per_point, _| {
+            if active_pixels_per_point.contains(pixels_per_point) {
+                true
+            } else {
+                #[cfg(feature = "log")]
+                log::trace!(
+                    "Freeing Fonts with pixels_per_point={} because it is no longer needed",
+                    pixels_per_point.into_inner()
+                );
+                false
+            }
+        });
 
-    if is_last {
-      // Remove dead viewports:
-      self.viewports.retain(|id, _| all_viewport_ids.contains(id));
-      self.viewport_parents.retain(|id, _| all_viewport_ids.contains(id));
-    } else {
-      let viewport_id = self.viewport_id();
-      self.memory.set_viewport_id(viewport_id);
+        FullOutput {
+            platform_output,
+            textures_delta,
+            shapes,
+            pixels_per_point,
+            viewport_output,
+        }
     }
-
-    let active_pixels_per_point: std::collections::BTreeSet<OrderedFloat<f32>> =
-      self.viewports.values().map(|v| v.input.pixels_per_point.into()).collect();
-    self.fonts.retain(|pixels_per_point, _| {
-      if active_pixels_per_point.contains(pixels_per_point) {
-        true
-      } else {
-        #[cfg(feature = "log")]
-        log::trace!(
-          "Freeing Fonts with pixels_per_point={} because it is no longer needed",
-          pixels_per_point.into_inner()
-        );
-        false
-      }
-    });
-
-    FullOutput { platform_output, textures_delta, shapes, pixels_per_point, viewport_output }
-  }
 }
 
 impl Context {
-  /// Tessellate the given shapes into triangle meshes.
-  ///
-  /// `pixels_per_point` is used for feathering (anti-aliasing).
-  /// For this you can use [`FullOutput::pixels_per_point`], [`Self::pixels_per_point`],
-  /// or whatever is appropriate for your viewport.
-  pub fn tessellate(&self, shapes: Vec<ClippedShape>, pixels_per_point: f32) -> Vec<ClippedPrimitive> {
-    crate::profile_function!();
+    /// Tessellate the given shapes into triangle meshes.
+    ///
+    /// `pixels_per_point` is used for feathering (anti-aliasing).
+    /// For this you can use [`FullOutput::pixels_per_point`], [`Self::pixels_per_point`],
+    /// or whatever is appropriate for your viewport.
+    pub fn tessellate(
+        &self,
+        shapes: Vec<ClippedShape>,
+        pixels_per_point: f32,
+    ) -> Vec<ClippedPrimitive> {
+        crate::profile_function!();
 
-    // A tempting optimization is to reuse the tessellation from last frame if the
-    // shapes are the same, but just comparing the shapes takes about 50% of the time
-    // it takes to tessellate them, so it is not a worth optimization.
+        // A tempting optimization is to reuse the tessellation from last frame if the
+        // shapes are the same, but just comparing the shapes takes about 50% of the time
+        // it takes to tessellate them, so it is not a worth optimization.
 
-    self.write(|ctx| {
+        self.write(|ctx| {
       let tessellation_options = ctx.memory.options.tessellation_options;
       let texture_atlas = ctx
         .fonts
@@ -2058,1165 +2234,1260 @@ impl Context {
       ctx.paint_stats = paint_stats.with_clipped_primitives(&clipped_primitives);
       clipped_primitives
     })
-  }
-
-  // ---------------------------------------------------------------------
-
-  /// Position and size of the egui area.
-  pub fn screen_rect(&self) -> Rect {
-    self.input(|i| i.screen_rect())
-  }
-
-  /// How much space is still available after panels has been added.
-  ///
-  /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
-  /// This is also the area to which windows are constrained.
-  pub fn available_rect(&self) -> Rect {
-    self.frame_state(|s| s.available_rect())
-  }
-
-  /// How much space is used by panels and windows.
-  pub fn used_rect(&self) -> Rect {
-    self.write(|ctx| {
-      let mut used = ctx.viewport().this_frame.used_by_panels;
-      for (_id, window) in ctx.memory.areas().visible_windows() {
-        used = used.union(window.rect());
-      }
-      used
-    })
-  }
-
-  /// How much space is used by panels and windows.
-  ///
-  /// You can shrink your egui area to this size and still fit all egui components.
-  pub fn used_size(&self) -> Vec2 {
-    self.used_rect().max - Pos2::ZERO
-  }
-
-  // ---------------------------------------------------------------------
-
-  /// Is the pointer (mouse/touch) over any egui area?
-  pub fn is_pointer_over_area(&self) -> bool {
-    let pointer_pos = self.input(|i| i.pointer.interact_pos());
-    if let Some(pointer_pos) = pointer_pos {
-      if let Some(layer) = self.layer_id_at(pointer_pos) {
-        if layer.order == Order::Background {
-          !self.frame_state(|state| state.unused_rect.contains(pointer_pos))
-        } else {
-          true
-        }
-      } else {
-        false
-      }
-    } else {
-      false
     }
-  }
 
-  /// True if egui is currently interested in the pointer (mouse or touch).
-  ///
-  /// Could be the pointer is hovering over a [`Window`] or the user is dragging a widget.
-  /// If `false`, the pointer is outside of any egui area and so
-  /// you may be interested in what it is doing (e.g. controlling your game).
-  /// Returns `false` if a drag started outside of egui and then moved over an egui area.
-  pub fn wants_pointer_input(&self) -> bool {
-    self.is_using_pointer() || (self.is_pointer_over_area() && !self.input(|i| i.pointer.any_down()))
-  }
+    // ---------------------------------------------------------------------
 
-  /// Is egui currently using the pointer position (e.g. dragging a slider)?
-  ///
-  /// NOTE: this will return `false` if the pointer is just hovering over an egui area.
-  pub fn is_using_pointer(&self) -> bool {
-    self.memory(|m| m.interaction().is_using_pointer())
-  }
+    /// Position and size of the egui area.
+    pub fn screen_rect(&self) -> Rect {
+        self.input(|i| i.screen_rect())
+    }
 
-  /// If `true`, egui is currently listening on text input (e.g. typing text in a [`TextEdit`]).
-  pub fn wants_keyboard_input(&self) -> bool {
-    self.memory(|m| m.focused().is_some())
-  }
+    /// How much space is still available after panels has been added.
+    ///
+    /// This is the "background" area, what egui doesn't cover with panels (but may cover with windows).
+    /// This is also the area to which windows are constrained.
+    pub fn available_rect(&self) -> Rect {
+        self.frame_state(|s| s.available_rect())
+    }
 
-  /// Highlight this widget, to make it look like it is hovered, even if it isn't.
-  ///
-  /// The highlight takes on frame to take effect if you call this after the widget has been fully rendered.
-  ///
-  /// See also [`Response::highlight`].
-  pub fn highlight_widget(&self, id: Id) {
-    self.frame_state_mut(|fs| fs.highlight_next_frame.insert(id));
-  }
+    /// How much space is used by panels and windows.
+    pub fn used_rect(&self) -> Rect {
+        self.write(|ctx| {
+            let mut used = ctx.viewport().this_frame.used_by_panels;
+            for (_id, window) in ctx.memory.areas().visible_windows() {
+                used = used.union(window.rect());
+            }
+            used
+        })
+    }
 
-  /// Is an egui context menu open?
-  pub fn is_context_menu_open(&self) -> bool {
-    self.data(|d| {
-      d.get_temp::<crate::menu::BarState>(menu::CONTEXT_MENU_ID_STR.into()).map_or(false, |state| state.has_root())
-    })
-  }
+    /// How much space is used by panels and windows.
+    ///
+    /// You can shrink your egui area to this size and still fit all egui components.
+    pub fn used_size(&self) -> Vec2 {
+        self.used_rect().max - Pos2::ZERO
+    }
+
+    // ---------------------------------------------------------------------
+
+    /// Is the pointer (mouse/touch) over any egui area?
+    pub fn is_pointer_over_area(&self) -> bool {
+        let pointer_pos = self.input(|i| i.pointer.interact_pos());
+        if let Some(pointer_pos) = pointer_pos {
+            if let Some(layer) = self.layer_id_at(pointer_pos) {
+                if layer.order == Order::Background {
+                    !self.frame_state(|state| state.unused_rect.contains(pointer_pos))
+                } else {
+                    true
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    /// True if egui is currently interested in the pointer (mouse or touch).
+    ///
+    /// Could be the pointer is hovering over a [`Window`] or the user is dragging a widget.
+    /// If `false`, the pointer is outside of any egui area and so
+    /// you may be interested in what it is doing (e.g. controlling your game).
+    /// Returns `false` if a drag started outside of egui and then moved over an egui area.
+    pub fn wants_pointer_input(&self) -> bool {
+        self.is_using_pointer()
+            || (self.is_pointer_over_area() && !self.input(|i| i.pointer.any_down()))
+    }
+
+    /// Is egui currently using the pointer position (e.g. dragging a slider)?
+    ///
+    /// NOTE: this will return `false` if the pointer is just hovering over an egui area.
+    pub fn is_using_pointer(&self) -> bool {
+        self.memory(|m| m.interaction().is_using_pointer())
+    }
+
+    /// If `true`, egui is currently listening on text input (e.g. typing text in a [`TextEdit`]).
+    pub fn wants_keyboard_input(&self) -> bool {
+        self.memory(|m| m.focused().is_some())
+    }
+
+    /// Highlight this widget, to make it look like it is hovered, even if it isn't.
+    ///
+    /// The highlight takes on frame to take effect if you call this after the widget has been fully rendered.
+    ///
+    /// See also [`Response::highlight`].
+    pub fn highlight_widget(&self, id: Id) {
+        self.frame_state_mut(|fs| fs.highlight_next_frame.insert(id));
+    }
+
+    /// Is an egui context menu open?
+    pub fn is_context_menu_open(&self) -> bool {
+        self.data(|d| {
+            d.get_temp::<crate::menu::BarState>(menu::CONTEXT_MENU_ID_STR.into())
+                .map_or(false, |state| state.has_root())
+        })
+    }
 }
 
 // Ergonomic methods to forward some calls often used in 'if let' without holding the borrow
 impl Context {
-  /// Latest reported pointer position.
-  ///
-  /// When tapping a touch screen, this will be `None`.
-  #[inline(always)]
-  pub fn pointer_latest_pos(&self) -> Option<Pos2> {
-    self.input(|i| i.pointer.latest_pos())
-  }
+    /// Latest reported pointer position.
+    ///
+    /// When tapping a touch screen, this will be `None`.
+    #[inline(always)]
+    pub fn pointer_latest_pos(&self) -> Option<Pos2> {
+        self.input(|i| i.pointer.latest_pos())
+    }
 
-  /// If it is a good idea to show a tooltip, where is pointer?
-  #[inline(always)]
-  pub fn pointer_hover_pos(&self) -> Option<Pos2> {
-    self.input(|i| i.pointer.hover_pos())
-  }
+    /// If it is a good idea to show a tooltip, where is pointer?
+    #[inline(always)]
+    pub fn pointer_hover_pos(&self) -> Option<Pos2> {
+        self.input(|i| i.pointer.hover_pos())
+    }
 
-  /// If you detect a click or drag and wants to know where it happened, use this.
-  ///
-  /// Latest position of the mouse, but ignoring any [`Event::PointerGone`]
-  /// if there were interactions this frame.
-  /// When tapping a touch screen, this will be the location of the touch.
-  #[inline(always)]
-  pub fn pointer_interact_pos(&self) -> Option<Pos2> {
-    self.input(|i| i.pointer.interact_pos())
-  }
+    /// If you detect a click or drag and wants to know where it happened, use this.
+    ///
+    /// Latest position of the mouse, but ignoring any [`Event::PointerGone`]
+    /// if there were interactions this frame.
+    /// When tapping a touch screen, this will be the location of the touch.
+    #[inline(always)]
+    pub fn pointer_interact_pos(&self) -> Option<Pos2> {
+        self.input(|i| i.pointer.interact_pos())
+    }
 
-  /// Calls [`InputState::multi_touch`].
-  pub fn multi_touch(&self) -> Option<MultiTouchInfo> {
-    self.input(|i| i.multi_touch())
-  }
+    /// Calls [`InputState::multi_touch`].
+    pub fn multi_touch(&self) -> Option<MultiTouchInfo> {
+        self.input(|i| i.multi_touch())
+    }
 }
 
 impl Context {
-  /// Transform the graphics of the given layer.
-  ///
-  /// This will also affect input.
-  ///
-  /// This is a sticky setting, remembered from one frame to the next.
-  ///
-  /// Can be used to implement pan and zoom (see relevant demo).
-  ///
-  /// For a temporary transform, use [`Self::transform_layer_shapes`] instead.
-  pub fn set_transform_layer(&self, layer_id: LayerId, transform: TSTransform) {
-    self.memory_mut(|m| {
-      if transform == TSTransform::IDENTITY {
-        m.layer_transforms.remove(&layer_id)
-      } else {
-        m.layer_transforms.insert(layer_id, transform)
-      }
-    });
-  }
-
-  /// Move all the graphics at the given layer.
-  ///
-  /// Is used to implement drag-and-drop preview.
-  ///
-  /// This only applied to the existing graphics at the layer, not to new graphics added later.
-  ///
-  /// For a persistent transform, use [`Self::set_transform_layer`] instead.
-  #[deprecated = "Use `transform_layer_shapes` instead"]
-  pub fn translate_layer(&self, layer_id: LayerId, delta: Vec2) {
-    if delta != Vec2::ZERO {
-      let transform = emath::TSTransform::from_translation(delta);
-      self.transform_layer_shapes(layer_id, transform);
-    }
-  }
-
-  /// Transform all the graphics at the given layer.
-  ///
-  /// Is used to implement drag-and-drop preview.
-  ///
-  /// This only applied to the existing graphics at the layer, not to new graphics added later.
-  ///
-  /// For a persistent transform, use [`Self::set_transform_layer`] instead.
-  pub fn transform_layer_shapes(&self, layer_id: LayerId, transform: TSTransform) {
-    if transform != TSTransform::IDENTITY {
-      self.graphics_mut(|g| g.entry(layer_id).transform(transform));
-    }
-  }
-
-  /// Top-most layer at the given position.
-  pub fn layer_id_at(&self, pos: Pos2) -> Option<LayerId> {
-    self.memory(|mem| mem.layer_id_at(pos))
-  }
-
-  /// Moves the given area to the top in its [`Order`].
-  ///
-  /// [`Area`]:s and [`Window`]:s also do this automatically when being clicked on or interacted with.
-  pub fn move_to_top(&self, layer_id: LayerId) {
-    self.memory_mut(|mem| mem.areas_mut().move_to_top(layer_id));
-  }
-
-  /// Mark the `child` layer as a sublayer of `parent`.
-  ///
-  /// Sublayers are moved directly above the parent layer at the end of the frame. This is mainly
-  /// intended for adding a new [`Area`] inside a [`Window`].
-  ///
-  /// This currently only supports one level of nesting. If `parent` is a sublayer of another
-  /// layer, the behavior is unspecified.
-  pub fn set_sublayer(&self, parent: LayerId, child: LayerId) {
-    self.memory_mut(|mem| mem.areas_mut().set_sublayer(parent, child));
-  }
-
-  /// Retrieve the [`LayerId`] of the top level windows.
-  pub fn top_layer_id(&self) -> Option<LayerId> {
-    self.memory(|mem| mem.areas().top_layer_id(Order::Middle))
-  }
-
-  /// Does the given rectangle contain the mouse pointer?
-  ///
-  /// Will return false if some other area is covering the given layer.
-  ///
-  /// The given rectangle is assumed to have been clipped by its parent clip rect.
-  ///
-  /// See also [`Response::contains_pointer`].
-  pub fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
-    let rect = if let Some(transform) = self.memory(|m| m.layer_transforms.get(&layer_id).copied()) {
-      transform * rect
-    } else {
-      rect
-    };
-    if !rect.is_positive() {
-      return false;
+    /// Transform the graphics of the given layer.
+    ///
+    /// This will also affect input.
+    ///
+    /// This is a sticky setting, remembered from one frame to the next.
+    ///
+    /// Can be used to implement pan and zoom (see relevant demo).
+    ///
+    /// For a temporary transform, use [`Self::transform_layer_shapes`] instead.
+    pub fn set_transform_layer(&self, layer_id: LayerId, transform: TSTransform) {
+        self.memory_mut(|m| {
+            if transform == TSTransform::IDENTITY {
+                m.layer_transforms.remove(&layer_id)
+            } else {
+                m.layer_transforms.insert(layer_id, transform)
+            }
+        });
     }
 
-    let pointer_pos = self.input(|i| i.pointer.interact_pos());
-    let Some(pointer_pos) = pointer_pos else {
-      return false;
-    };
-
-    if !rect.contains(pointer_pos) {
-      return false;
+    /// Move all the graphics at the given layer.
+    ///
+    /// Is used to implement drag-and-drop preview.
+    ///
+    /// This only applied to the existing graphics at the layer, not to new graphics added later.
+    ///
+    /// For a persistent transform, use [`Self::set_transform_layer`] instead.
+    #[deprecated = "Use `transform_layer_shapes` instead"]
+    pub fn translate_layer(&self, layer_id: LayerId, delta: Vec2) {
+        if delta != Vec2::ZERO {
+            let transform = emath::TSTransform::from_translation(delta);
+            self.transform_layer_shapes(layer_id, transform);
+        }
     }
 
-    if self.layer_id_at(pointer_pos) != Some(layer_id) {
-      return false;
+    /// Transform all the graphics at the given layer.
+    ///
+    /// Is used to implement drag-and-drop preview.
+    ///
+    /// This only applied to the existing graphics at the layer, not to new graphics added later.
+    ///
+    /// For a persistent transform, use [`Self::set_transform_layer`] instead.
+    pub fn transform_layer_shapes(&self, layer_id: LayerId, transform: TSTransform) {
+        if transform != TSTransform::IDENTITY {
+            self.graphics_mut(|g| g.entry(layer_id).transform(transform));
+        }
     }
 
-    true
-  }
+    /// Top-most layer at the given position.
+    pub fn layer_id_at(&self, pos: Pos2) -> Option<LayerId> {
+        self.memory(|mem| mem.layer_id_at(pos))
+    }
 
-  // ---------------------------------------------------------------------
+    /// Moves the given area to the top in its [`Order`].
+    ///
+    /// [`Area`]:s and [`Window`]:s also do this automatically when being clicked on or interacted with.
+    pub fn move_to_top(&self, layer_id: LayerId) {
+        self.memory_mut(|mem| mem.areas_mut().move_to_top(layer_id));
+    }
 
-  /// Whether or not to debug widget layout on hover.
-  #[cfg(debug_assertions)]
-  pub fn debug_on_hover(&self) -> bool {
-    self.options(|opt| opt.style.debug.debug_on_hover)
-  }
+    /// Mark the `child` layer as a sublayer of `parent`.
+    ///
+    /// Sublayers are moved directly above the parent layer at the end of the frame. This is mainly
+    /// intended for adding a new [`Area`] inside a [`Window`].
+    ///
+    /// This currently only supports one level of nesting. If `parent` is a sublayer of another
+    /// layer, the behavior is unspecified.
+    pub fn set_sublayer(&self, parent: LayerId, child: LayerId) {
+        self.memory_mut(|mem| mem.areas_mut().set_sublayer(parent, child));
+    }
 
-  /// Turn on/off whether or not to debug widget layout on hover.
-  #[cfg(debug_assertions)]
-  pub fn set_debug_on_hover(&self, debug_on_hover: bool) {
-    self.style_mut(|style| style.debug.debug_on_hover = debug_on_hover);
-  }
+    /// Retrieve the [`LayerId`] of the top level windows.
+    pub fn top_layer_id(&self) -> Option<LayerId> {
+        self.memory(|mem| mem.areas().top_layer_id(Order::Middle))
+    }
+
+    /// Does the given rectangle contain the mouse pointer?
+    ///
+    /// Will return false if some other area is covering the given layer.
+    ///
+    /// The given rectangle is assumed to have been clipped by its parent clip rect.
+    ///
+    /// See also [`Response::contains_pointer`].
+    pub fn rect_contains_pointer(&self, layer_id: LayerId, rect: Rect) -> bool {
+        let rect =
+            if let Some(transform) = self.memory(|m| m.layer_transforms.get(&layer_id).copied()) {
+                transform * rect
+            } else {
+                rect
+            };
+        if !rect.is_positive() {
+            return false;
+        }
+
+        let pointer_pos = self.input(|i| i.pointer.interact_pos());
+        let Some(pointer_pos) = pointer_pos else {
+            return false;
+        };
+
+        if !rect.contains(pointer_pos) {
+            return false;
+        }
+
+        if self.layer_id_at(pointer_pos) != Some(layer_id) {
+            return false;
+        }
+
+        true
+    }
+
+    // ---------------------------------------------------------------------
+
+    /// Whether or not to debug widget layout on hover.
+    #[cfg(debug_assertions)]
+    pub fn debug_on_hover(&self) -> bool {
+        self.options(|opt| opt.style.debug.debug_on_hover)
+    }
+
+    /// Turn on/off whether or not to debug widget layout on hover.
+    #[cfg(debug_assertions)]
+    pub fn set_debug_on_hover(&self, debug_on_hover: bool) {
+        self.style_mut(|style| style.debug.debug_on_hover = debug_on_hover);
+    }
 }
 
 /// ## Animation
 impl Context {
-  /// Returns a value in the range [0, 1], to indicate "how on" this thing is.
-  ///
-  /// The first time called it will return `if value { 1.0 } else { 0.0 }`
-  /// Calling this with `value = true` will always yield a number larger than zero, quickly going towards one.
-  /// Calling this with `value = false` will always yield a number less than one, quickly going towards zero.
-  ///
-  /// The function will call [`Self::request_repaint()`] when appropriate.
-  ///
-  /// The animation time is taken from [`Style::animation_time`].
-  #[track_caller] // To track repaint cause
-  pub fn animate_bool(&self, id: Id, value: bool) -> f32 {
-    let animation_time = self.style().animation_time;
-    self.animate_bool_with_time_and_easing(id, value, animation_time, emath::easing::linear)
-  }
-
-  /// Like [`Self::animate_bool`], but uses an easing function that makes the value move
-  /// quickly in the beginning and slow down towards the end.
-  ///
-  /// The exact easing function may come to change in future versions of egui.
-  #[track_caller] // To track repaint cause
-  pub fn animate_bool_responsive(&self, id: Id, value: bool) -> f32 {
-    self.animate_bool_with_easing(id, value, emath::easing::cubic_out)
-  }
-
-  /// Like [`Self::animate_bool`] but allows you to control the easing function.
-  #[track_caller] // To track repaint cause
-  pub fn animate_bool_with_easing(&self, id: Id, value: bool, easing: fn(f32) -> f32) -> f32 {
-    let animation_time = self.style().animation_time;
-    self.animate_bool_with_time_and_easing(id, value, animation_time, easing)
-  }
-
-  /// Like [`Self::animate_bool`] but allows you to control the animation time.
-  #[track_caller] // To track repaint cause
-  pub fn animate_bool_with_time(&self, id: Id, target_value: bool, animation_time: f32) -> f32 {
-    self.animate_bool_with_time_and_easing(id, target_value, animation_time, emath::easing::linear)
-  }
-
-  /// Like [`Self::animate_bool`] but allows you to control the animation time and easing function.
-  ///
-  /// Use e.g. [`emath::easing::quadratic_out`]
-  /// for a responsive start and a slow end.
-  ///
-  /// The easing function flips when `target_value` is `false`,
-  /// so that when going back towards 0.0, we get
-  #[track_caller] // To track repaint cause
-  pub fn animate_bool_with_time_and_easing(
-    &self,
-    id: Id,
-    target_value: bool,
-    animation_time: f32,
-    easing: fn(f32) -> f32,
-  ) -> f32 {
-    let animated_value = self.write(|ctx| {
-      ctx.animation_manager.animate_bool(
-        &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
-        animation_time,
-        id,
-        target_value,
-      )
-    });
-
-    let animation_in_progress = 0.0 < animated_value && animated_value < 1.0;
-    if animation_in_progress {
-      self.request_repaint();
+    /// Returns a value in the range [0, 1], to indicate "how on" this thing is.
+    ///
+    /// The first time called it will return `if value { 1.0 } else { 0.0 }`
+    /// Calling this with `value = true` will always yield a number larger than zero, quickly going towards one.
+    /// Calling this with `value = false` will always yield a number less than one, quickly going towards zero.
+    ///
+    /// The function will call [`Self::request_repaint()`] when appropriate.
+    ///
+    /// The animation time is taken from [`Style::animation_time`].
+    #[track_caller] // To track repaint cause
+    pub fn animate_bool(&self, id: Id, value: bool) -> f32 {
+        let animation_time = self.style().animation_time;
+        self.animate_bool_with_time_and_easing(id, value, animation_time, emath::easing::linear)
     }
 
-    if target_value {
-      easing(animated_value)
-    } else {
-      1.0 - easing(1.0 - animated_value)
-    }
-  }
-
-  /// Smoothly animate an `f32` value.
-  ///
-  /// At the first call the value is written to memory.
-  /// When it is called with a new value, it linearly interpolates to it in the given time.
-  #[track_caller] // To track repaint cause
-  pub fn animate_value_with_time(&self, id: Id, target_value: f32, animation_time: f32) -> f32 {
-    let animated_value = self.write(|ctx| {
-      ctx.animation_manager.animate_value(
-        &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
-        animation_time,
-        id,
-        target_value,
-      )
-    });
-    let animation_in_progress = animated_value != target_value;
-    if animation_in_progress {
-      self.request_repaint();
+    /// Like [`Self::animate_bool`], but uses an easing function that makes the value move
+    /// quickly in the beginning and slow down towards the end.
+    ///
+    /// The exact easing function may come to change in future versions of egui.
+    #[track_caller] // To track repaint cause
+    pub fn animate_bool_responsive(&self, id: Id, value: bool) -> f32 {
+        self.animate_bool_with_easing(id, value, emath::easing::cubic_out)
     }
 
-    animated_value
-  }
-
-  /// Clear memory of any animations.
-  pub fn clear_animations(&self) {
-    self.write(|ctx| ctx.animation_manager = Default::default());
-  }
-}
-
-impl Context {
-  /// Show a ui for settings (style and tessellation options).
-  pub fn settings_ui(&self, ui: &mut Ui) {
-    let prev_options = self.options(|o| o.clone());
-    let mut options = prev_options.clone();
-
-    options.ui(ui);
-
-    if options != prev_options {
-      self.options_mut(move |o| *o = options);
-    }
-  }
-
-  /// Show the state of egui, including its input and output.
-  pub fn inspection_ui(&self, ui: &mut Ui) {
-    use crate::containers::*;
-
-    ui.label(format!("Is using pointer: {}", self.is_using_pointer()))
-      .on_hover_text("Is egui currently using the pointer actively (e.g. dragging a slider)?");
-    ui.label(format!("Wants pointer input: {}", self.wants_pointer_input()))
-            .on_hover_text("Is egui currently interested in the location of the pointer (either because it is in use, or because it is hovering over a window).");
-    ui.label(format!("Wants keyboard input: {}", self.wants_keyboard_input()))
-      .on_hover_text("Is egui currently listening for text input?");
-    ui.label(format!(
-      "Keyboard focus widget: {}",
-      self.memory(|m| m.focused()).as_ref().map(Id::short_debug_format).unwrap_or_default()
-    ))
-    .on_hover_text("Is egui currently listening for text input?");
-
-    let pointer_pos = self.pointer_hover_pos().map_or_else(String::new, |pos| format!("{pos:?}"));
-    ui.label(format!("Pointer pos: {pointer_pos}"));
-
-    let top_layer = self
-      .pointer_hover_pos()
-      .and_then(|pos| self.layer_id_at(pos))
-      .map_or_else(String::new, |layer| layer.short_debug_format());
-    ui.label(format!("Top layer under mouse: {top_layer}"));
-
-    ui.add_space(16.0);
-
-    ui.label(format!("There are {} text galleys in the layout cache", self.fonts(|f| f.num_galleys_in_cache())))
-      .on_hover_text("This is approximately the number of text strings on screen");
-    ui.add_space(16.0);
-
-    CollapsingHeader::new("🔃 Repaint Causes").default_open(false).show(ui, |ui| {
-      ui.set_min_height(120.0);
-      ui.label("What caused egui to repaint:");
-      ui.add_space(8.0);
-      let causes = ui.ctx().repaint_causes();
-      for cause in causes {
-        ui.label(cause.to_string());
-      }
-    });
-
-    CollapsingHeader::new("📥 Input").default_open(false).show(ui, |ui| {
-      let input = ui.input(|i| i.clone());
-      input.ui(ui);
-    });
-
-    CollapsingHeader::new("📊 Paint stats").default_open(false).show(ui, |ui| {
-      let paint_stats = self.read(|ctx| ctx.paint_stats);
-      paint_stats.ui(ui);
-    });
-
-    CollapsingHeader::new("🖼 Textures").default_open(false).show(ui, |ui| {
-      self.texture_ui(ui);
-    });
-
-    CollapsingHeader::new("🔠 Font texture").default_open(false).show(ui, |ui| {
-      let font_image_size = self.fonts(|f| f.font_image_size());
-      crate::introspection::font_texture_ui(ui, font_image_size);
-    });
-
-    CollapsingHeader::new("Label text selection state").default_open(false).show(ui, |ui| {
-      ui.label(format!("{:#?}", crate::text_selection::LabelSelectionState::load(ui.ctx())));
-    });
-
-    CollapsingHeader::new("Interaction").default_open(false).show(ui, |ui| {
-      let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
-      interact_widgets.ui(ui);
-    });
-  }
-
-  /// Show stats about the allocated textures.
-  pub fn texture_ui(&self, ui: &mut crate::Ui) {
-    let tex_mngr = self.tex_manager();
-    let tex_mngr = tex_mngr.read();
-
-    let mut textures: Vec<_> = tex_mngr.allocated().collect();
-    textures.sort_by_key(|(id, _)| *id);
-
-    let mut bytes = 0;
-    for (_, tex) in &textures {
-      bytes += tex.bytes_used();
+    /// Like [`Self::animate_bool`] but allows you to control the easing function.
+    #[track_caller] // To track repaint cause
+    pub fn animate_bool_with_easing(&self, id: Id, value: bool, easing: fn(f32) -> f32) -> f32 {
+        let animation_time = self.style().animation_time;
+        self.animate_bool_with_time_and_easing(id, value, animation_time, easing)
     }
 
-    ui.label(format!("{} allocated texture(s), using {:.1} MB", textures.len(), bytes as f64 * 1e-6));
-    let max_preview_size = vec2(48.0, 32.0);
-
-    ui.group(|ui| {
-      ScrollArea::vertical().max_height(300.0).auto_shrink([false, true]).show(ui, |ui| {
-        ui.style_mut().override_text_style = Some(TextStyle::Monospace);
-        Grid::new("textures")
-          .striped(true)
-          .num_columns(4)
-          .spacing(vec2(16.0, 2.0))
-          .min_row_height(max_preview_size.y)
-          .show(ui, |ui| {
-            for (&texture_id, meta) in textures {
-              let [w, h] = meta.size;
-
-              let mut size = vec2(w as f32, h as f32);
-              size *= (max_preview_size.x / size.x).min(1.0);
-              size *= (max_preview_size.y / size.y).min(1.0);
-              ui.image(SizedTexture::new(texture_id, size)).on_hover_ui(|ui| {
-                // show larger on hover
-                let max_size = 0.5 * ui.ctx().screen_rect().size();
-                let mut size = vec2(w as f32, h as f32);
-                size *= max_size.x / size.x.max(max_size.x);
-                size *= max_size.y / size.y.max(max_size.y);
-                ui.image(SizedTexture::new(texture_id, size));
-              });
-
-              ui.label(format!("{w} x {h}"));
-              ui.label(format!("{:.3} MB", meta.bytes_used() as f64 * 1e-6));
-              ui.label(format!("{:?}", meta.name));
-              ui.end_row();
-            }
-          });
-      });
-    });
-  }
-
-  /// Shows the contents of [`Self::memory`].
-  pub fn memory_ui(&self, ui: &mut crate::Ui) {
-    if ui.button("Reset all").on_hover_text("Reset all egui state").clicked() {
-      self.memory_mut(|mem| *mem = Default::default());
+    /// Like [`Self::animate_bool`] but allows you to control the animation time.
+    #[track_caller] // To track repaint cause
+    pub fn animate_bool_with_time(&self, id: Id, target_value: bool, animation_time: f32) -> f32 {
+        self.animate_bool_with_time_and_easing(
+            id,
+            target_value,
+            animation_time,
+            emath::easing::linear,
+        )
     }
 
-    let (num_state, num_serialized) = self.data(|d| (d.len(), d.count_serialized()));
-    ui.label(format!("{num_state} widget states stored (of which {num_serialized} are serialized)."));
+    /// Like [`Self::animate_bool`] but allows you to control the animation time and easing function.
+    ///
+    /// Use e.g. [`emath::easing::quadratic_out`]
+    /// for a responsive start and a slow end.
+    ///
+    /// The easing function flips when `target_value` is `false`,
+    /// so that when going back towards 0.0, we get
+    #[track_caller] // To track repaint cause
+    pub fn animate_bool_with_time_and_easing(
+        &self,
+        id: Id,
+        target_value: bool,
+        animation_time: f32,
+        easing: fn(f32) -> f32,
+    ) -> f32 {
+        let animated_value = self.write(|ctx| {
+            ctx.animation_manager.animate_bool(
+                &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
+                animation_time,
+                id,
+                target_value,
+            )
+        });
 
-    ui.horizontal(|ui| {
-      ui.label(format!("{} areas (panels, windows, popups, …)", self.memory(|mem| mem.areas().count())));
-      if ui.button("Reset").clicked() {
-        self.memory_mut(|mem| *mem.areas_mut() = Default::default());
-      }
-    });
-    ui.indent("areas", |ui| {
-      ui.label("Visible areas, ordered back to front.");
-      ui.label("Hover to highlight");
-      let layers_ids: Vec<LayerId> = self.memory(|mem| mem.areas().order().to_vec());
-      for layer_id in layers_ids {
-        let area = AreaState::load(self, layer_id.id);
-        if let Some(area) = area {
-          let is_visible = self.memory(|mem| mem.areas().is_visible(&layer_id));
-          if !is_visible {
-            continue;
-          }
-          let text = format!("{} - {:?}", layer_id.short_debug_format(), area.rect(),);
-          // TODO(emilk): `Sense::hover_highlight()`
-          if ui.add(Label::new(RichText::new(text).monospace()).sense(Sense::click())).hovered && is_visible {
-            ui.ctx().debug_painter().debug_rect(area.rect(), Color32::RED, "");
-          }
+        let animation_in_progress = 0.0 < animated_value && animated_value < 1.0;
+        if animation_in_progress {
+            self.request_repaint();
         }
-      }
-    });
 
-    ui.horizontal(|ui| {
-      ui.label(format!("{} collapsing headers", self.data(|d| d.count::<containers::collapsing_header::InnerState>())));
-      if ui.button("Reset").clicked() {
-        self.data_mut(|d| d.remove_by_type::<containers::collapsing_header::InnerState>());
-      }
-    });
+        if target_value {
+            easing(animated_value)
+        } else {
+            1.0 - easing(1.0 - animated_value)
+        }
+    }
 
-    ui.horizontal(|ui| {
-      ui.label(format!("{} menu bars", self.data(|d| d.count::<menu::BarState>())));
-      if ui.button("Reset").clicked() {
-        self.data_mut(|d| d.remove_by_type::<menu::BarState>());
-      }
-    });
+    /// Smoothly animate an `f32` value.
+    ///
+    /// At the first call the value is written to memory.
+    /// When it is called with a new value, it linearly interpolates to it in the given time.
+    #[track_caller] // To track repaint cause
+    pub fn animate_value_with_time(&self, id: Id, target_value: f32, animation_time: f32) -> f32 {
+        let animated_value = self.write(|ctx| {
+            ctx.animation_manager.animate_value(
+                &ctx.viewports.entry(ctx.viewport_id()).or_default().input,
+                animation_time,
+                id,
+                target_value,
+            )
+        });
+        let animation_in_progress = animated_value != target_value;
+        if animation_in_progress {
+            self.request_repaint();
+        }
 
-    ui.horizontal(|ui| {
-      ui.label(format!("{} scroll areas", self.data(|d| d.count::<scroll_area::State>())));
-      if ui.button("Reset").clicked() {
-        self.data_mut(|d| d.remove_by_type::<scroll_area::State>());
-      }
-    });
+        animated_value
+    }
 
-    ui.horizontal(|ui| {
-      ui.label(format!("{} resize areas", self.data(|d| d.count::<resize::State>())));
-      if ui.button("Reset").clicked() {
-        self.data_mut(|d| d.remove_by_type::<resize::State>());
-      }
-    });
-
-    ui.shrink_width_to_current(); // don't let the text below grow this window wider
-    ui.label("NOTE: the position of this window cannot be reset from within itself.");
-
-    ui.collapsing("Interaction", |ui| {
-      let interaction = self.memory(|mem| mem.interaction().clone());
-      interaction.ui(ui);
-    });
-  }
+    /// Clear memory of any animations.
+    pub fn clear_animations(&self) {
+        self.write(|ctx| ctx.animation_manager = Default::default());
+    }
 }
 
 impl Context {
-  /// Edit the active [`Style`].
-  pub fn style_ui(&self, ui: &mut Ui) {
-    let mut style: Style = (*self.style()).clone();
-    style.ui(ui);
-    self.set_style(style);
-  }
+    /// Show a ui for settings (style and tessellation options).
+    pub fn settings_ui(&self, ui: &mut Ui) {
+        let prev_options = self.options(|o| o.clone());
+        let mut options = prev_options.clone();
+
+        options.ui(ui);
+
+        if options != prev_options {
+            self.options_mut(move |o| *o = options);
+        }
+    }
+
+    /// Show the state of egui, including its input and output.
+    pub fn inspection_ui(&self, ui: &mut Ui) {
+        use crate::containers::*;
+
+        ui.label(format!("Is using pointer: {}", self.is_using_pointer()))
+            .on_hover_text(
+                "Is egui currently using the pointer actively (e.g. dragging a slider)?",
+            );
+        ui.label(format!("Wants pointer input: {}", self.wants_pointer_input()))
+            .on_hover_text("Is egui currently interested in the location of the pointer (either because it is in use, or because it is hovering over a window).");
+        ui.label(format!(
+            "Wants keyboard input: {}",
+            self.wants_keyboard_input()
+        ))
+        .on_hover_text("Is egui currently listening for text input?");
+        ui.label(format!(
+            "Keyboard focus widget: {}",
+            self.memory(|m| m.focused())
+                .as_ref()
+                .map(Id::short_debug_format)
+                .unwrap_or_default()
+        ))
+        .on_hover_text("Is egui currently listening for text input?");
+
+        let pointer_pos = self
+            .pointer_hover_pos()
+            .map_or_else(String::new, |pos| format!("{pos:?}"));
+        ui.label(format!("Pointer pos: {pointer_pos}"));
+
+        let top_layer = self
+            .pointer_hover_pos()
+            .and_then(|pos| self.layer_id_at(pos))
+            .map_or_else(String::new, |layer| layer.short_debug_format());
+        ui.label(format!("Top layer under mouse: {top_layer}"));
+
+        ui.add_space(16.0);
+
+        ui.label(format!(
+            "There are {} text galleys in the layout cache",
+            self.fonts(|f| f.num_galleys_in_cache())
+        ))
+        .on_hover_text("This is approximately the number of text strings on screen");
+        ui.add_space(16.0);
+
+        CollapsingHeader::new("🔃 Repaint Causes")
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.set_min_height(120.0);
+                ui.label("What caused egui to repaint:");
+                ui.add_space(8.0);
+                let causes = ui.ctx().repaint_causes();
+                for cause in causes {
+                    ui.label(cause.to_string());
+                }
+            });
+
+        CollapsingHeader::new("📥 Input")
+            .default_open(false)
+            .show(ui, |ui| {
+                let input = ui.input(|i| i.clone());
+                input.ui(ui);
+            });
+
+        CollapsingHeader::new("📊 Paint stats")
+            .default_open(false)
+            .show(ui, |ui| {
+                let paint_stats = self.read(|ctx| ctx.paint_stats);
+                paint_stats.ui(ui);
+            });
+
+        CollapsingHeader::new("🖼 Textures")
+            .default_open(false)
+            .show(ui, |ui| {
+                self.texture_ui(ui);
+            });
+
+        CollapsingHeader::new("🔠 Font texture")
+            .default_open(false)
+            .show(ui, |ui| {
+                let font_image_size = self.fonts(|f| f.font_image_size());
+                crate::introspection::font_texture_ui(ui, font_image_size);
+            });
+
+        CollapsingHeader::new("Label text selection state")
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.label(format!(
+                    "{:#?}",
+                    crate::text_selection::LabelSelectionState::load(ui.ctx())
+                ));
+            });
+
+        CollapsingHeader::new("Interaction")
+            .default_open(false)
+            .show(ui, |ui| {
+                let interact_widgets = self.write(|ctx| ctx.viewport().interact_widgets.clone());
+                interact_widgets.ui(ui);
+            });
+    }
+
+    /// Show stats about the allocated textures.
+    pub fn texture_ui(&self, ui: &mut crate::Ui) {
+        let tex_mngr = self.tex_manager();
+        let tex_mngr = tex_mngr.read();
+
+        let mut textures: Vec<_> = tex_mngr.allocated().collect();
+        textures.sort_by_key(|(id, _)| *id);
+
+        let mut bytes = 0;
+        for (_, tex) in &textures {
+            bytes += tex.bytes_used();
+        }
+
+        ui.label(format!(
+            "{} allocated texture(s), using {:.1} MB",
+            textures.len(),
+            bytes as f64 * 1e-6
+        ));
+        let max_preview_size = vec2(48.0, 32.0);
+
+        ui.group(|ui| {
+            ScrollArea::vertical()
+                .max_height(300.0)
+                .auto_shrink([false, true])
+                .show(ui, |ui| {
+                    ui.style_mut().override_text_style = Some(TextStyle::Monospace);
+                    Grid::new("textures")
+                        .striped(true)
+                        .num_columns(4)
+                        .spacing(vec2(16.0, 2.0))
+                        .min_row_height(max_preview_size.y)
+                        .show(ui, |ui| {
+                            for (&texture_id, meta) in textures {
+                                let [w, h] = meta.size;
+
+                                let mut size = vec2(w as f32, h as f32);
+                                size *= (max_preview_size.x / size.x).min(1.0);
+                                size *= (max_preview_size.y / size.y).min(1.0);
+                                ui.image(SizedTexture::new(texture_id, size))
+                                    .on_hover_ui(|ui| {
+                                        // show larger on hover
+                                        let max_size = 0.5 * ui.ctx().screen_rect().size();
+                                        let mut size = vec2(w as f32, h as f32);
+                                        size *= max_size.x / size.x.max(max_size.x);
+                                        size *= max_size.y / size.y.max(max_size.y);
+                                        ui.image(SizedTexture::new(texture_id, size));
+                                    });
+
+                                ui.label(format!("{w} x {h}"));
+                                ui.label(format!("{:.3} MB", meta.bytes_used() as f64 * 1e-6));
+                                ui.label(format!("{:?}", meta.name));
+                                ui.end_row();
+                            }
+                        });
+                });
+        });
+    }
+
+    /// Shows the contents of [`Self::memory`].
+    pub fn memory_ui(&self, ui: &mut crate::Ui) {
+        if ui
+            .button("Reset all")
+            .on_hover_text("Reset all egui state")
+            .clicked()
+        {
+            self.memory_mut(|mem| *mem = Default::default());
+        }
+
+        let (num_state, num_serialized) = self.data(|d| (d.len(), d.count_serialized()));
+        ui.label(format!(
+            "{num_state} widget states stored (of which {num_serialized} are serialized)."
+        ));
+
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "{} areas (panels, windows, popups, …)",
+                self.memory(|mem| mem.areas().count())
+            ));
+            if ui.button("Reset").clicked() {
+                self.memory_mut(|mem| *mem.areas_mut() = Default::default());
+            }
+        });
+        ui.indent("areas", |ui| {
+            ui.label("Visible areas, ordered back to front.");
+            ui.label("Hover to highlight");
+            let layers_ids: Vec<LayerId> = self.memory(|mem| mem.areas().order().to_vec());
+            for layer_id in layers_ids {
+                let area = AreaState::load(self, layer_id.id);
+                if let Some(area) = area {
+                    let is_visible = self.memory(|mem| mem.areas().is_visible(&layer_id));
+                    if !is_visible {
+                        continue;
+                    }
+                    let text = format!("{} - {:?}", layer_id.short_debug_format(), area.rect(),);
+                    // TODO(emilk): `Sense::hover_highlight()`
+                    if ui
+                        .add(Label::new(RichText::new(text).monospace()).sense(Sense::click()))
+                        .hovered
+                        && is_visible
+                    {
+                        ui.ctx()
+                            .debug_painter()
+                            .debug_rect(area.rect(), Color32::RED, "");
+                    }
+                }
+            }
+        });
+
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "{} collapsing headers",
+                self.data(|d| d.count::<containers::collapsing_header::InnerState>())
+            ));
+            if ui.button("Reset").clicked() {
+                self.data_mut(|d| d.remove_by_type::<containers::collapsing_header::InnerState>());
+            }
+        });
+
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "{} menu bars",
+                self.data(|d| d.count::<menu::BarState>())
+            ));
+            if ui.button("Reset").clicked() {
+                self.data_mut(|d| d.remove_by_type::<menu::BarState>());
+            }
+        });
+
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "{} scroll areas",
+                self.data(|d| d.count::<scroll_area::State>())
+            ));
+            if ui.button("Reset").clicked() {
+                self.data_mut(|d| d.remove_by_type::<scroll_area::State>());
+            }
+        });
+
+        ui.horizontal(|ui| {
+            ui.label(format!(
+                "{} resize areas",
+                self.data(|d| d.count::<resize::State>())
+            ));
+            if ui.button("Reset").clicked() {
+                self.data_mut(|d| d.remove_by_type::<resize::State>());
+            }
+        });
+
+        ui.shrink_width_to_current(); // don't let the text below grow this window wider
+        ui.label("NOTE: the position of this window cannot be reset from within itself.");
+
+        ui.collapsing("Interaction", |ui| {
+            let interaction = self.memory(|mem| mem.interaction().clone());
+            interaction.ui(ui);
+        });
+    }
+}
+
+impl Context {
+    /// Edit the active [`Style`].
+    pub fn style_ui(&self, ui: &mut Ui) {
+        let mut style: Style = (*self.style()).clone();
+        style.ui(ui);
+        self.set_style(style);
+    }
 }
 
 /// ## Accessibility
 impl Context {
-  /// Call the provided function with the given ID pushed on the stack of
-  /// parent IDs for accessibility purposes. If the `accesskit` feature
-  /// is disabled or if AccessKit support is not active for this frame,
-  /// the function is still called, but with no other effect.
-  ///
-  /// No locks are held while the given closure is called.
-  #[allow(clippy::unused_self)]
-  #[inline]
-  pub fn with_accessibility_parent(&self, _id: Id, f: impl FnOnce()) {
-    // TODO(emilk): this isn't thread-safe - another thread can call this function between the push/pop calls
+    /// Call the provided function with the given ID pushed on the stack of
+    /// parent IDs for accessibility purposes. If the `accesskit` feature
+    /// is disabled or if AccessKit support is not active for this frame,
+    /// the function is still called, but with no other effect.
+    ///
+    /// No locks are held while the given closure is called.
+    #[allow(clippy::unused_self)]
+    #[inline]
+    pub fn with_accessibility_parent(&self, _id: Id, f: impl FnOnce()) {
+        // TODO(emilk): this isn't thread-safe - another thread can call this function between the push/pop calls
+        #[cfg(feature = "accesskit")]
+        self.frame_state_mut(|fs| {
+            if let Some(state) = fs.accesskit_state.as_mut() {
+                state.parent_stack.push(_id);
+            }
+        });
+
+        f();
+
+        #[cfg(feature = "accesskit")]
+        self.frame_state_mut(|fs| {
+            if let Some(state) = fs.accesskit_state.as_mut() {
+                assert_eq!(state.parent_stack.pop(), Some(_id));
+            }
+        });
+    }
+
+    /// If AccessKit support is active for the current frame, get or create
+    /// a node builder with the specified ID and return a mutable reference to it.
+    /// For newly created nodes, the parent is the node with the ID at the top
+    /// of the stack managed by [`Context::with_accessibility_parent`].
+    ///
+    /// The `Context` lock is held while the given closure is called!
+    ///
+    /// Returns `None` if acesskit is off.
+    // TODO(emilk): consider making both read-only and read-write versions
     #[cfg(feature = "accesskit")]
-    self.frame_state_mut(|fs| {
-      if let Some(state) = fs.accesskit_state.as_mut() {
-        state.parent_stack.push(_id);
-      }
-    });
+    pub fn accesskit_node_builder<R>(
+        &self,
+        id: Id,
+        writer: impl FnOnce(&mut accesskit::NodeBuilder) -> R,
+    ) -> Option<R> {
+        self.write(|ctx| {
+            ctx.viewport()
+                .this_frame
+                .accesskit_state
+                .is_some()
+                .then(|| ctx.accesskit_node_builder(id))
+                .map(writer)
+        })
+    }
 
-    f();
-
+    /// Enable generation of AccessKit tree updates in all future frames.
+    ///
+    /// If it's practical for the egui integration to immediately run the egui
+    /// application when it is either initializing the AccessKit adapter or
+    /// being called by the AccessKit adapter to provide the initial tree update,
+    /// then it should do so, to provide a complete AccessKit tree to the adapter
+    /// immediately. Otherwise, it should enqueue a repaint and use the
+    /// placeholder tree update from [`Context::accesskit_placeholder_tree_update`]
+    /// in the meantime.
     #[cfg(feature = "accesskit")]
-    self.frame_state_mut(|fs| {
-      if let Some(state) = fs.accesskit_state.as_mut() {
-        assert_eq!(state.parent_stack.pop(), Some(_id));
-      }
-    });
-  }
+    pub fn enable_accesskit(&self) {
+        self.write(|ctx| ctx.is_accesskit_enabled = true);
+    }
 
-  /// If AccessKit support is active for the current frame, get or create
-  /// a node builder with the specified ID and return a mutable reference to it.
-  /// For newly created nodes, the parent is the node with the ID at the top
-  /// of the stack managed by [`Context::with_accessibility_parent`].
-  ///
-  /// The `Context` lock is held while the given closure is called!
-  ///
-  /// Returns `None` if acesskit is off.
-  // TODO(emilk): consider making both read-only and read-write versions
-  #[cfg(feature = "accesskit")]
-  pub fn accesskit_node_builder<R>(&self, id: Id, writer: impl FnOnce(&mut accesskit::NodeBuilder) -> R) -> Option<R> {
-    self.write(|ctx| {
-      ctx.viewport().this_frame.accesskit_state.is_some().then(|| ctx.accesskit_node_builder(id)).map(writer)
-    })
-  }
+    /// Return a tree update that the egui integration should provide to the
+    /// AccessKit adapter if it cannot immediately run the egui application
+    /// to get a full tree update after running [`Context::enable_accesskit`].
+    #[cfg(feature = "accesskit")]
+    pub fn accesskit_placeholder_tree_update(&self) -> accesskit::TreeUpdate {
+        crate::profile_function!();
 
-  /// Enable generation of AccessKit tree updates in all future frames.
-  ///
-  /// If it's practical for the egui integration to immediately run the egui
-  /// application when it is either initializing the AccessKit adapter or
-  /// being called by the AccessKit adapter to provide the initial tree update,
-  /// then it should do so, to provide a complete AccessKit tree to the adapter
-  /// immediately. Otherwise, it should enqueue a repaint and use the
-  /// placeholder tree update from [`Context::accesskit_placeholder_tree_update`]
-  /// in the meantime.
-  #[cfg(feature = "accesskit")]
-  pub fn enable_accesskit(&self) {
-    self.write(|ctx| ctx.is_accesskit_enabled = true);
-  }
+        use accesskit::{NodeBuilder, Role, Tree, TreeUpdate};
 
-  /// Return a tree update that the egui integration should provide to the
-  /// AccessKit adapter if it cannot immediately run the egui application
-  /// to get a full tree update after running [`Context::enable_accesskit`].
-  #[cfg(feature = "accesskit")]
-  pub fn accesskit_placeholder_tree_update(&self) -> accesskit::TreeUpdate {
-    crate::profile_function!();
-
-    use accesskit::{NodeBuilder, Role, Tree, TreeUpdate};
-
-    let root_id = crate::accesskit_root_id().accesskit_id();
-    self.write(|ctx| TreeUpdate {
-      nodes: vec![(root_id, NodeBuilder::new(Role::Window).build(&mut ctx.accesskit_node_classes))],
-      tree: Some(Tree::new(root_id)),
-      focus: root_id,
-    })
-  }
+        let root_id = crate::accesskit_root_id().accesskit_id();
+        self.write(|ctx| TreeUpdate {
+            nodes: vec![(
+                root_id,
+                NodeBuilder::new(Role::Window).build(&mut ctx.accesskit_node_classes),
+            )],
+            tree: Some(Tree::new(root_id)),
+            focus: root_id,
+        })
+    }
 }
 
 /// ## Image loading
 impl Context {
-  /// Associate some static bytes with a `uri`.
-  ///
-  /// The same `uri` may be passed to [`Ui::image`] later to load the bytes as an image.
-  ///
-  /// By convention, the `uri` should start with `bytes://`.
-  /// Following that convention will lead to better error messages.
-  pub fn include_bytes(&self, uri: impl Into<Cow<'static, str>>, bytes: impl Into<Bytes>) {
-    self.loaders().include.insert(uri, bytes);
-  }
-
-  /// Returns `true` if the chain of bytes, image, or texture loaders
-  /// contains a loader with the given `id`.
-  pub fn is_loader_installed(&self, id: &str) -> bool {
-    let loaders = self.loaders();
-
-    loaders.bytes.lock().iter().any(|l| l.id() == id)
-      || loaders.image.lock().iter().any(|l| l.id() == id)
-      || loaders.texture.lock().iter().any(|l| l.id() == id)
-  }
-
-  /// Add a new bytes loader.
-  ///
-  /// It will be tried first, before any already installed loaders.
-  ///
-  /// See [`load`] for more information.
-  pub fn add_bytes_loader(&self, loader: Arc<dyn load::BytesLoader + Send + Sync + 'static>) {
-    self.loaders().bytes.lock().push(loader);
-  }
-
-  /// Add a new image loader.
-  ///
-  /// It will be tried first, before any already installed loaders.
-  ///
-  /// See [`load`] for more information.
-  pub fn add_image_loader(&self, loader: Arc<dyn load::ImageLoader + Send + Sync + 'static>) {
-    self.loaders().image.lock().push(loader);
-  }
-
-  /// Add a new texture loader.
-  ///
-  /// It will be tried first, before any already installed loaders.
-  ///
-  /// See [`load`] for more information.
-  pub fn add_texture_loader(&self, loader: Arc<dyn load::TextureLoader + Send + Sync + 'static>) {
-    self.loaders().texture.lock().push(loader);
-  }
-
-  /// Release all memory and textures related to the given image URI.
-  ///
-  /// If you attempt to load the image again, it will be reloaded from scratch.
-  pub fn forget_image(&self, uri: &str) {
-    use load::BytesLoader as _;
-
-    crate::profile_function!();
-
-    let loaders = self.loaders();
-
-    loaders.include.forget(uri);
-    for loader in loaders.bytes.lock().iter() {
-      loader.forget(uri);
-    }
-    for loader in loaders.image.lock().iter() {
-      loader.forget(uri);
-    }
-    for loader in loaders.texture.lock().iter() {
-      loader.forget(uri);
-    }
-  }
-
-  /// Release all memory and textures related to images used in [`Ui::image`] or [`Image`].
-  ///
-  /// If you attempt to load any images again, they will be reloaded from scratch.
-  pub fn forget_all_images(&self) {
-    use load::BytesLoader as _;
-
-    crate::profile_function!();
-
-    let loaders = self.loaders();
-
-    loaders.include.forget_all();
-    for loader in loaders.bytes.lock().iter() {
-      loader.forget_all();
-    }
-    for loader in loaders.image.lock().iter() {
-      loader.forget_all();
-    }
-    for loader in loaders.texture.lock().iter() {
-      loader.forget_all();
-    }
-  }
-
-  /// Try loading the bytes from the given uri using any available bytes loaders.
-  ///
-  /// Loaders are expected to cache results, so that this call is immediate-mode safe.
-  ///
-  /// This calls the loaders one by one in the order in which they were registered.
-  /// If a loader returns [`LoadError::NotSupported`][not_supported],
-  /// then the next loader is called. This process repeats until all loaders have
-  /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
-  ///
-  /// # Errors
-  /// This may fail with:
-  /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
-  /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
-  ///
-  /// ⚠ May deadlock if called from within a `BytesLoader`!
-  ///
-  /// [not_supported]: crate::load::LoadError::NotSupported
-  /// [custom]: crate::load::LoadError::Loading
-  pub fn try_load_bytes(&self, uri: &str) -> load::BytesLoadResult {
-    crate::profile_function!(uri);
-
-    let loaders = self.loaders();
-    let bytes_loaders = loaders.bytes.lock();
-
-    // Try most recently added loaders first (hence `.rev()`)
-    for loader in bytes_loaders.iter().rev() {
-      match loader.load(self, uri) {
-        Err(load::LoadError::NotSupported) => continue,
-        result => return result,
-      }
+    /// Associate some static bytes with a `uri`.
+    ///
+    /// The same `uri` may be passed to [`Ui::image`] later to load the bytes as an image.
+    ///
+    /// By convention, the `uri` should start with `bytes://`.
+    /// Following that convention will lead to better error messages.
+    pub fn include_bytes(&self, uri: impl Into<Cow<'static, str>>, bytes: impl Into<Bytes>) {
+        self.loaders().include.insert(uri, bytes);
     }
 
-    Err(load::LoadError::NoMatchingBytesLoader)
-  }
+    /// Returns `true` if the chain of bytes, image, or texture loaders
+    /// contains a loader with the given `id`.
+    pub fn is_loader_installed(&self, id: &str) -> bool {
+        let loaders = self.loaders();
 
-  /// Try loading the image from the given uri using any available image loaders.
-  ///
-  /// Loaders are expected to cache results, so that this call is immediate-mode safe.
-  ///
-  /// This calls the loaders one by one in the order in which they were registered.
-  /// If a loader returns [`LoadError::NotSupported`][not_supported],
-  /// then the next loader is called. This process repeats until all loaders have
-  /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
-  ///
-  /// # Errors
-  /// This may fail with:
-  /// - [`LoadError::NoImageLoaders`][no_image_loaders] if tbere are no registered image loaders.
-  /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
-  /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
-  ///
-  /// ⚠ May deadlock if called from within an `ImageLoader`!
-  ///
-  /// [no_image_loaders]: crate::load::LoadError::NoImageLoaders
-  /// [not_supported]: crate::load::LoadError::NotSupported
-  /// [custom]: crate::load::LoadError::Loading
-  pub fn try_load_image(&self, uri: &str, size_hint: load::SizeHint) -> load::ImageLoadResult {
-    crate::profile_function!(uri);
-
-    let loaders = self.loaders();
-    let image_loaders = loaders.image.lock();
-    if image_loaders.is_empty() {
-      return Err(load::LoadError::NoImageLoaders);
+        loaders.bytes.lock().iter().any(|l| l.id() == id)
+            || loaders.image.lock().iter().any(|l| l.id() == id)
+            || loaders.texture.lock().iter().any(|l| l.id() == id)
     }
 
-    // Try most recently added loaders first (hence `.rev()`)
-    for loader in image_loaders.iter().rev() {
-      match loader.load(self, uri, size_hint) {
-        Err(load::LoadError::NotSupported) => continue,
-        result => return result,
-      }
+    /// Add a new bytes loader.
+    ///
+    /// It will be tried first, before any already installed loaders.
+    ///
+    /// See [`load`] for more information.
+    pub fn add_bytes_loader(&self, loader: Arc<dyn load::BytesLoader + Send + Sync + 'static>) {
+        self.loaders().bytes.lock().push(loader);
     }
 
-    Err(load::LoadError::NoMatchingImageLoader)
-  }
-
-  /// Try loading the texture from the given uri using any available texture loaders.
-  ///
-  /// Loaders are expected to cache results, so that this call is immediate-mode safe.
-  ///
-  /// This calls the loaders one by one in the order in which they were registered.
-  /// If a loader returns [`LoadError::NotSupported`][not_supported],
-  /// then the next loader is called. This process repeats until all loaders have
-  /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
-  ///
-  /// # Errors
-  /// This may fail with:
-  /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
-  /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
-  ///
-  /// ⚠ May deadlock if called from within a `TextureLoader`!
-  ///
-  /// [not_supported]: crate::load::LoadError::NotSupported
-  /// [custom]: crate::load::LoadError::Loading
-  pub fn try_load_texture(
-    &self,
-    uri: &str,
-    texture_options: TextureOptions,
-    size_hint: load::SizeHint,
-  ) -> load::TextureLoadResult {
-    crate::profile_function!(uri);
-
-    let loaders = self.loaders();
-    let texture_loaders = loaders.texture.lock();
-
-    // Try most recently added loaders first (hence `.rev()`)
-    for loader in texture_loaders.iter().rev() {
-      match loader.load(self, uri, texture_options, size_hint) {
-        Err(load::LoadError::NotSupported) => continue,
-        result => return result,
-      }
+    /// Add a new image loader.
+    ///
+    /// It will be tried first, before any already installed loaders.
+    ///
+    /// See [`load`] for more information.
+    pub fn add_image_loader(&self, loader: Arc<dyn load::ImageLoader + Send + Sync + 'static>) {
+        self.loaders().image.lock().push(loader);
     }
 
-    Err(load::LoadError::NoMatchingTextureLoader)
-  }
+    /// Add a new texture loader.
+    ///
+    /// It will be tried first, before any already installed loaders.
+    ///
+    /// See [`load`] for more information.
+    pub fn add_texture_loader(&self, loader: Arc<dyn load::TextureLoader + Send + Sync + 'static>) {
+        self.loaders().texture.lock().push(loader);
+    }
 
-  /// The loaders of bytes, images, and textures.
-  pub fn loaders(&self) -> Arc<Loaders> {
-    crate::profile_function!();
-    self.read(|this| this.loaders.clone())
-  }
+    /// Release all memory and textures related to the given image URI.
+    ///
+    /// If you attempt to load the image again, it will be reloaded from scratch.
+    pub fn forget_image(&self, uri: &str) {
+        use load::BytesLoader as _;
+
+        crate::profile_function!();
+
+        let loaders = self.loaders();
+
+        loaders.include.forget(uri);
+        for loader in loaders.bytes.lock().iter() {
+            loader.forget(uri);
+        }
+        for loader in loaders.image.lock().iter() {
+            loader.forget(uri);
+        }
+        for loader in loaders.texture.lock().iter() {
+            loader.forget(uri);
+        }
+    }
+
+    /// Release all memory and textures related to images used in [`Ui::image`] or [`Image`].
+    ///
+    /// If you attempt to load any images again, they will be reloaded from scratch.
+    pub fn forget_all_images(&self) {
+        use load::BytesLoader as _;
+
+        crate::profile_function!();
+
+        let loaders = self.loaders();
+
+        loaders.include.forget_all();
+        for loader in loaders.bytes.lock().iter() {
+            loader.forget_all();
+        }
+        for loader in loaders.image.lock().iter() {
+            loader.forget_all();
+        }
+        for loader in loaders.texture.lock().iter() {
+            loader.forget_all();
+        }
+    }
+
+    /// Try loading the bytes from the given uri using any available bytes loaders.
+    ///
+    /// Loaders are expected to cache results, so that this call is immediate-mode safe.
+    ///
+    /// This calls the loaders one by one in the order in which they were registered.
+    /// If a loader returns [`LoadError::NotSupported`][not_supported],
+    /// then the next loader is called. This process repeats until all loaders have
+    /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
+    ///
+    /// # Errors
+    /// This may fail with:
+    /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
+    /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
+    ///
+    /// ⚠ May deadlock if called from within a `BytesLoader`!
+    ///
+    /// [not_supported]: crate::load::LoadError::NotSupported
+    /// [custom]: crate::load::LoadError::Loading
+    pub fn try_load_bytes(&self, uri: &str) -> load::BytesLoadResult {
+        crate::profile_function!(uri);
+
+        let loaders = self.loaders();
+        let bytes_loaders = loaders.bytes.lock();
+
+        // Try most recently added loaders first (hence `.rev()`)
+        for loader in bytes_loaders.iter().rev() {
+            match loader.load(self, uri) {
+                Err(load::LoadError::NotSupported) => continue,
+                result => return result,
+            }
+        }
+
+        Err(load::LoadError::NoMatchingBytesLoader)
+    }
+
+    /// Try loading the image from the given uri using any available image loaders.
+    ///
+    /// Loaders are expected to cache results, so that this call is immediate-mode safe.
+    ///
+    /// This calls the loaders one by one in the order in which they were registered.
+    /// If a loader returns [`LoadError::NotSupported`][not_supported],
+    /// then the next loader is called. This process repeats until all loaders have
+    /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
+    ///
+    /// # Errors
+    /// This may fail with:
+    /// - [`LoadError::NoImageLoaders`][no_image_loaders] if tbere are no registered image loaders.
+    /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
+    /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
+    ///
+    /// ⚠ May deadlock if called from within an `ImageLoader`!
+    ///
+    /// [no_image_loaders]: crate::load::LoadError::NoImageLoaders
+    /// [not_supported]: crate::load::LoadError::NotSupported
+    /// [custom]: crate::load::LoadError::Loading
+    pub fn try_load_image(&self, uri: &str, size_hint: load::SizeHint) -> load::ImageLoadResult {
+        crate::profile_function!(uri);
+
+        let loaders = self.loaders();
+        let image_loaders = loaders.image.lock();
+        if image_loaders.is_empty() {
+            return Err(load::LoadError::NoImageLoaders);
+        }
+
+        // Try most recently added loaders first (hence `.rev()`)
+        for loader in image_loaders.iter().rev() {
+            match loader.load(self, uri, size_hint) {
+                Err(load::LoadError::NotSupported) => continue,
+                result => return result,
+            }
+        }
+
+        Err(load::LoadError::NoMatchingImageLoader)
+    }
+
+    /// Try loading the texture from the given uri using any available texture loaders.
+    ///
+    /// Loaders are expected to cache results, so that this call is immediate-mode safe.
+    ///
+    /// This calls the loaders one by one in the order in which they were registered.
+    /// If a loader returns [`LoadError::NotSupported`][not_supported],
+    /// then the next loader is called. This process repeats until all loaders have
+    /// been exhausted, at which point this returns [`LoadError::NotSupported`][not_supported].
+    ///
+    /// # Errors
+    /// This may fail with:
+    /// - [`LoadError::NotSupported`][not_supported] if none of the registered loaders support loading the given `uri`.
+    /// - [`LoadError::Loading`][custom] if one of the loaders _does_ support loading the `uri`, but the loading process failed.
+    ///
+    /// ⚠ May deadlock if called from within a `TextureLoader`!
+    ///
+    /// [not_supported]: crate::load::LoadError::NotSupported
+    /// [custom]: crate::load::LoadError::Loading
+    pub fn try_load_texture(
+        &self,
+        uri: &str,
+        texture_options: TextureOptions,
+        size_hint: load::SizeHint,
+    ) -> load::TextureLoadResult {
+        crate::profile_function!(uri);
+
+        let loaders = self.loaders();
+        let texture_loaders = loaders.texture.lock();
+
+        // Try most recently added loaders first (hence `.rev()`)
+        for loader in texture_loaders.iter().rev() {
+            match loader.load(self, uri, texture_options, size_hint) {
+                Err(load::LoadError::NotSupported) => continue,
+                result => return result,
+            }
+        }
+
+        Err(load::LoadError::NoMatchingTextureLoader)
+    }
+
+    /// The loaders of bytes, images, and textures.
+    pub fn loaders(&self) -> Arc<Loaders> {
+        crate::profile_function!();
+        self.read(|this| this.loaders.clone())
+    }
 }
 
 /// ## Viewports
 impl Context {
-  /// Return the `ViewportId` of the current viewport.
-  ///
-  /// If this is the root viewport, this will return [`ViewportId::ROOT`].
-  ///
-  /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
-  pub fn viewport_id(&self) -> ViewportId {
-    self.read(|ctx| ctx.viewport_id())
-  }
-
-  /// Return the `ViewportId` of his parent.
-  ///
-  /// If this is the root viewport, this will return [`ViewportId::ROOT`].
-  ///
-  /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
-  pub fn parent_viewport_id(&self) -> ViewportId {
-    self.read(|ctx| ctx.parent_viewport_id())
-  }
-
-  /// Read the state of the current viewport.
-  pub fn viewport<R>(&self, reader: impl FnOnce(&ViewportState) -> R) -> R {
-    self.write(|ctx| reader(ctx.viewport()))
-  }
-
-  /// Read the state of a specific current viewport.
-  pub fn viewport_for<R>(&self, viewport_id: ViewportId, reader: impl FnOnce(&ViewportState) -> R) -> R {
-    self.write(|ctx| reader(ctx.viewport_for(viewport_id)))
-  }
-
-  /// For integrations: Set this to render a sync viewport.
-  ///
-  /// This will only set the callback for the current thread,
-  /// which most likely should be the main thread.
-  ///
-  /// When an immediate viewport is created with [`Self::show_viewport_immediate`] it will be rendered by this function.
-  ///
-  /// When called, the integration needs to:
-  /// * Check if there already is a window for this viewport id, and if not open one
-  /// * Set the window attributes (position, size, …) based on [`ImmediateViewport::builder`].
-  /// * Call [`Context::run`] with [`ImmediateViewport::viewport_ui_cb`].
-  /// * Handle the output from [`Context::run`], including rendering
-  #[allow(clippy::unused_self)]
-  pub fn set_immediate_viewport_renderer(callback: impl for<'a> Fn(&Self, ImmediateViewport<'a>) + 'static) {
-    let callback = Box::new(callback);
-    IMMEDIATE_VIEWPORT_RENDERER.with(|render_sync| {
-      render_sync.replace(Some(callback));
-    });
-  }
-
-  /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
-  /// embed the new viewports inside the existing one, instead of spawning a new native window.
-  ///
-  /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
-  pub fn embed_viewports(&self) -> bool {
-    self.read(|ctx| ctx.embed_viewports)
-  }
-
-  /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
-  /// embed the new viewports inside the existing one, instead of spawning a new native window.
-  ///
-  /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
-  pub fn set_embed_viewports(&self, value: bool) {
-    self.write(|ctx| ctx.embed_viewports = value);
-  }
-
-  /// Send a command to the current viewport.
-  ///
-  /// This lets you affect the current viewport, e.g. resizing the window.
-  pub fn send_viewport_cmd(&self, command: ViewportCommand) {
-    self.send_viewport_cmd_to(self.viewport_id(), command);
-  }
-
-  /// Send a command to a specific viewport.
-  ///
-  /// This lets you affect another viewport, e.g. resizing its window.
-  pub fn send_viewport_cmd_to(&self, id: ViewportId, command: ViewportCommand) {
-    self.request_repaint_of(id);
-
-    if command.requires_parent_repaint() {
-      self.request_repaint_of(self.parent_viewport_id());
+    /// Return the `ViewportId` of the current viewport.
+    ///
+    /// If this is the root viewport, this will return [`ViewportId::ROOT`].
+    ///
+    /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
+    pub fn viewport_id(&self) -> ViewportId {
+        self.read(|ctx| ctx.viewport_id())
     }
 
-    self.write(|ctx| ctx.viewport_for(id).commands.push(command));
-  }
-
-  /// Show a deferred viewport, creating a new native window, if possible.
-  ///
-  /// The given id must be unique for each viewport.
-  ///
-  /// You need to call this each frame when the child viewport should exist.
-  ///
-  /// You can check if the user wants to close the viewport by checking the
-  /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
-  ///
-  /// The given callback will be called whenever the child viewport needs repainting,
-  /// e.g. on an event or when [`Self::request_repaint`] is called.
-  /// This means it may be called multiple times, for instance while the
-  /// parent viewport (the caller) is sleeping but the child viewport is animating.
-  ///
-  /// You will need to wrap your viewport state in an `Arc<RwLock<T>>` or `Arc<Mutex<T>>`.
-  /// When this is called again with the same id in `ViewportBuilder` the render function for that viewport will be updated.
-  ///
-  /// You can also use [`Self::show_viewport_immediate`], which uses a simpler `FnOnce`
-  /// with no need for `Send` or `Sync`. The downside is that it will require
-  /// the parent viewport (the caller) to repaint anytime the child is repainted,
-  /// and vice versa.
-  ///
-  /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
-  /// backend does not support multiple viewports), the given callback
-  /// will be called immediately, embedding the new viewport in the current one.
-  /// You can check this with the [`ViewportClass`] given in the callback.
-  /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
-  ///
-  /// See [`crate::viewport`] for more information about viewports.
-  pub fn show_viewport_deferred(
-    &self,
-    new_viewport_id: ViewportId,
-    viewport_builder: ViewportBuilder,
-    viewport_ui_cb: impl Fn(&Self, ViewportClass) + Send + Sync + 'static,
-  ) {
-    crate::profile_function!();
-
-    if self.embed_viewports() {
-      viewport_ui_cb(self, ViewportClass::Embedded);
-    } else {
-      self.write(|ctx| {
-        ctx.viewport_parents.insert(new_viewport_id, ctx.viewport_id());
-
-        let viewport = ctx.viewports.entry(new_viewport_id).or_default();
-        viewport.class = ViewportClass::Deferred;
-        viewport.builder = viewport_builder;
-        viewport.used = true;
-        viewport.viewport_ui_cb = Some(Arc::new(move |ctx| {
-          (viewport_ui_cb)(ctx, ViewportClass::Deferred);
-        }));
-      });
-    }
-  }
-
-  /// Show an immediate viewport, creating a new native window, if possible.
-  ///
-  /// This is the easier type of viewport to use, but it is less performant
-  /// at it requires both parent and child to repaint if any one of them needs repainting,
-  /// which efficvely produce double work for two viewports, and triple work for three viewports, etc.
-  /// To avoid this, use [`Self::show_viewport_deferred`] instead.
-  ///
-  /// The given id must be unique for each viewport.
-  ///
-  /// You need to call this each frame when the child viewport should exist.
-  ///
-  /// You can check if the user wants to close the viewport by checking the
-  /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
-  ///
-  /// The given ui function will be called immediately.
-  /// This may only be called on the main thread.
-  /// This call will pause the current viewport and render the child viewport in its own window.
-  /// This means that the child viewport will not be repainted when the parent viewport is repainted, and vice versa.
-  ///
-  /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
-  /// backend does not support multiple viewports), the given callback
-  /// will be called immediately, embedding the new viewport in the current one.
-  /// You can check this with the [`ViewportClass`] given in the callback.
-  /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
-  ///
-  /// See [`crate::viewport`] for more information about viewports.
-  pub fn show_viewport_immediate<T>(
-    &self,
-    new_viewport_id: ViewportId,
-    builder: ViewportBuilder,
-    viewport_ui_cb: impl FnOnce(&Self, ViewportClass) -> T,
-  ) -> T {
-    crate::profile_function!();
-
-    if self.embed_viewports() {
-      return viewport_ui_cb(self, ViewportClass::Embedded);
+    /// Return the `ViewportId` of his parent.
+    ///
+    /// If this is the root viewport, this will return [`ViewportId::ROOT`].
+    ///
+    /// Don't use this outside of `Self::run`, or after `Self::end_frame`.
+    pub fn parent_viewport_id(&self) -> ViewportId {
+        self.read(|ctx| ctx.parent_viewport_id())
     }
 
-    IMMEDIATE_VIEWPORT_RENDERER.with(|immediate_viewport_renderer| {
-      let immediate_viewport_renderer = immediate_viewport_renderer.borrow();
-      let Some(immediate_viewport_renderer) = immediate_viewport_renderer.as_ref() else {
-        // This egui backend does not support multiple viewports.
-        return viewport_ui_cb(self, ViewportClass::Embedded);
-      };
+    /// Read the state of the current viewport.
+    pub fn viewport<R>(&self, reader: impl FnOnce(&ViewportState) -> R) -> R {
+        self.write(|ctx| reader(ctx.viewport()))
+    }
 
-      let ids = self.write(|ctx| {
-        let parent_viewport_id = ctx.viewport_id();
+    /// Read the state of a specific current viewport.
+    pub fn viewport_for<R>(
+        &self,
+        viewport_id: ViewportId,
+        reader: impl FnOnce(&ViewportState) -> R,
+    ) -> R {
+        self.write(|ctx| reader(ctx.viewport_for(viewport_id)))
+    }
 
-        ctx.viewport_parents.insert(new_viewport_id, parent_viewport_id);
+    /// For integrations: Set this to render a sync viewport.
+    ///
+    /// This will only set the callback for the current thread,
+    /// which most likely should be the main thread.
+    ///
+    /// When an immediate viewport is created with [`Self::show_viewport_immediate`] it will be rendered by this function.
+    ///
+    /// When called, the integration needs to:
+    /// * Check if there already is a window for this viewport id, and if not open one
+    /// * Set the window attributes (position, size, …) based on [`ImmediateViewport::builder`].
+    /// * Call [`Context::run`] with [`ImmediateViewport::viewport_ui_cb`].
+    /// * Handle the output from [`Context::run`], including rendering
+    #[allow(clippy::unused_self)]
+    pub fn set_immediate_viewport_renderer(
+        callback: impl for<'a> Fn(&Self, ImmediateViewport<'a>) + 'static,
+    ) {
+        let callback = Box::new(callback);
+        IMMEDIATE_VIEWPORT_RENDERER.with(|render_sync| {
+            render_sync.replace(Some(callback));
+        });
+    }
 
-        let viewport = ctx.viewports.entry(new_viewport_id).or_default();
-        viewport.builder = builder.clone();
-        viewport.used = true;
-        viewport.viewport_ui_cb = None; // it is immediate
+    /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
+    /// embed the new viewports inside the existing one, instead of spawning a new native window.
+    ///
+    /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
+    pub fn embed_viewports(&self) -> bool {
+        self.read(|ctx| ctx.embed_viewports)
+    }
 
-        ViewportIdPair::from_self_and_parent(new_viewport_id, parent_viewport_id)
-      });
+    /// If `true`, [`Self::show_viewport_deferred`] and [`Self::show_viewport_immediate`] will
+    /// embed the new viewports inside the existing one, instead of spawning a new native window.
+    ///
+    /// `eframe` sets this to `false` on supported platforms, but the default value is `true`.
+    pub fn set_embed_viewports(&self, value: bool) {
+        self.write(|ctx| ctx.embed_viewports = value);
+    }
 
-      let mut out = None;
-      {
-        let out = &mut out;
+    /// Send a command to the current viewport.
+    ///
+    /// This lets you affect the current viewport, e.g. resizing the window.
+    pub fn send_viewport_cmd(&self, command: ViewportCommand) {
+        self.send_viewport_cmd_to(self.viewport_id(), command);
+    }
 
-        let viewport = ImmediateViewport {
-          ids,
-          builder,
-          viewport_ui_cb: Box::new(move |context| {
-            *out = Some(viewport_ui_cb(context, ViewportClass::Immediate));
-          }),
-        };
+    /// Send a command to a specific viewport.
+    ///
+    /// This lets you affect another viewport, e.g. resizing its window.
+    pub fn send_viewport_cmd_to(&self, id: ViewportId, command: ViewportCommand) {
+        self.request_repaint_of(id);
 
-        immediate_viewport_renderer(self, viewport);
-      }
+        if command.requires_parent_repaint() {
+            self.request_repaint_of(self.parent_viewport_id());
+        }
 
-      out.expect("egui backend is implemented incorrectly - the user callback was never called")
-    })
-  }
+        self.write(|ctx| ctx.viewport_for(id).commands.push(command));
+    }
+
+    /// Show a deferred viewport, creating a new native window, if possible.
+    ///
+    /// The given id must be unique for each viewport.
+    ///
+    /// You need to call this each frame when the child viewport should exist.
+    ///
+    /// You can check if the user wants to close the viewport by checking the
+    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
+    ///
+    /// The given callback will be called whenever the child viewport needs repainting,
+    /// e.g. on an event or when [`Self::request_repaint`] is called.
+    /// This means it may be called multiple times, for instance while the
+    /// parent viewport (the caller) is sleeping but the child viewport is animating.
+    ///
+    /// You will need to wrap your viewport state in an `Arc<RwLock<T>>` or `Arc<Mutex<T>>`.
+    /// When this is called again with the same id in `ViewportBuilder` the render function for that viewport will be updated.
+    ///
+    /// You can also use [`Self::show_viewport_immediate`], which uses a simpler `FnOnce`
+    /// with no need for `Send` or `Sync`. The downside is that it will require
+    /// the parent viewport (the caller) to repaint anytime the child is repainted,
+    /// and vice versa.
+    ///
+    /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
+    /// backend does not support multiple viewports), the given callback
+    /// will be called immediately, embedding the new viewport in the current one.
+    /// You can check this with the [`ViewportClass`] given in the callback.
+    /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
+    ///
+    /// See [`crate::viewport`] for more information about viewports.
+    pub fn show_viewport_deferred(
+        &self,
+        new_viewport_id: ViewportId,
+        viewport_builder: ViewportBuilder,
+        viewport_ui_cb: impl Fn(&Self, ViewportClass) + Send + Sync + 'static,
+    ) {
+        crate::profile_function!();
+
+        if self.embed_viewports() {
+            viewport_ui_cb(self, ViewportClass::Embedded);
+        } else {
+            self.write(|ctx| {
+                ctx.viewport_parents
+                    .insert(new_viewport_id, ctx.viewport_id());
+
+                let viewport = ctx.viewports.entry(new_viewport_id).or_default();
+                viewport.class = ViewportClass::Deferred;
+                viewport.builder = viewport_builder;
+                viewport.used = true;
+                viewport.viewport_ui_cb = Some(Arc::new(move |ctx| {
+                    (viewport_ui_cb)(ctx, ViewportClass::Deferred);
+                }));
+            });
+        }
+    }
+
+    /// Show an immediate viewport, creating a new native window, if possible.
+    ///
+    /// This is the easier type of viewport to use, but it is less performant
+    /// at it requires both parent and child to repaint if any one of them needs repainting,
+    /// which efficvely produce double work for two viewports, and triple work for three viewports, etc.
+    /// To avoid this, use [`Self::show_viewport_deferred`] instead.
+    ///
+    /// The given id must be unique for each viewport.
+    ///
+    /// You need to call this each frame when the child viewport should exist.
+    ///
+    /// You can check if the user wants to close the viewport by checking the
+    /// [`crate::ViewportInfo::close_requested`] flags found in [`crate::InputState::viewport`].
+    ///
+    /// The given ui function will be called immediately.
+    /// This may only be called on the main thread.
+    /// This call will pause the current viewport and render the child viewport in its own window.
+    /// This means that the child viewport will not be repainted when the parent viewport is repainted, and vice versa.
+    ///
+    /// If [`Context::embed_viewports`] is `true` (e.g. if the current egui
+    /// backend does not support multiple viewports), the given callback
+    /// will be called immediately, embedding the new viewport in the current one.
+    /// You can check this with the [`ViewportClass`] given in the callback.
+    /// If you find [`ViewportClass::Embedded`], you need to create a new [`crate::Window`] for you content.
+    ///
+    /// See [`crate::viewport`] for more information about viewports.
+    pub fn show_viewport_immediate<T>(
+        &self,
+        new_viewport_id: ViewportId,
+        builder: ViewportBuilder,
+        viewport_ui_cb: impl FnOnce(&Self, ViewportClass) -> T,
+    ) -> T {
+        crate::profile_function!();
+
+        if self.embed_viewports() {
+            return viewport_ui_cb(self, ViewportClass::Embedded);
+        }
+
+        IMMEDIATE_VIEWPORT_RENDERER.with(|immediate_viewport_renderer| {
+            let immediate_viewport_renderer = immediate_viewport_renderer.borrow();
+            let Some(immediate_viewport_renderer) = immediate_viewport_renderer.as_ref() else {
+                // This egui backend does not support multiple viewports.
+                return viewport_ui_cb(self, ViewportClass::Embedded);
+            };
+
+            let ids = self.write(|ctx| {
+                let parent_viewport_id = ctx.viewport_id();
+
+                ctx.viewport_parents
+                    .insert(new_viewport_id, parent_viewport_id);
+
+                let viewport = ctx.viewports.entry(new_viewport_id).or_default();
+                viewport.builder = builder.clone();
+                viewport.used = true;
+                viewport.viewport_ui_cb = None; // it is immediate
+
+                ViewportIdPair::from_self_and_parent(new_viewport_id, parent_viewport_id)
+            });
+
+            let mut out = None;
+            {
+                let out = &mut out;
+
+                let viewport = ImmediateViewport {
+                    ids,
+                    builder,
+                    viewport_ui_cb: Box::new(move |context| {
+                        *out = Some(viewport_ui_cb(context, ViewportClass::Immediate));
+                    }),
+                };
+
+                immediate_viewport_renderer(self, viewport);
+            }
+
+            out.expect(
+                "egui backend is implemented incorrectly - the user callback was never called",
+            )
+        })
+    }
 }
 
 /// ## Interaction
 impl Context {
-  /// Read you what widgets are currently being interacted with.
-  pub fn interaction_snapshot<R>(&self, reader: impl FnOnce(&InteractionSnapshot) -> R) -> R {
-    self.write(|w| reader(&w.viewport().interact_widgets))
-  }
+    /// Read you what widgets are currently being interacted with.
+    pub fn interaction_snapshot<R>(&self, reader: impl FnOnce(&InteractionSnapshot) -> R) -> R {
+        self.write(|w| reader(&w.viewport().interact_widgets))
+    }
 
-  /// The widget currently being dragged, if any.
-  ///
-  /// For widgets that sense both clicks and drags, this will
-  /// not be set until the mouse cursor has moved a certain distance.
-  ///
-  /// NOTE: if the widget was released this frame, this will be `None`.
-  /// Use [`Self::drag_stopped_id`] instead.
-  pub fn dragged_id(&self) -> Option<Id> {
-    self.interaction_snapshot(|i| i.dragged)
-  }
+    /// The widget currently being dragged, if any.
+    ///
+    /// For widgets that sense both clicks and drags, this will
+    /// not be set until the mouse cursor has moved a certain distance.
+    ///
+    /// NOTE: if the widget was released this frame, this will be `None`.
+    /// Use [`Self::drag_stopped_id`] instead.
+    pub fn dragged_id(&self) -> Option<Id> {
+        self.interaction_snapshot(|i| i.dragged)
+    }
 
-  /// Is this specific widget being dragged?
-  ///
-  /// A widget that sense both clicks and drags is only marked as "dragged"
-  /// when the mouse has moved a bit
-  ///
-  /// See also: [`crate::Response::dragged`].
-  pub fn is_being_dragged(&self, id: Id) -> bool {
-    self.dragged_id() == Some(id)
-  }
+    /// Is this specific widget being dragged?
+    ///
+    /// A widget that sense both clicks and drags is only marked as "dragged"
+    /// when the mouse has moved a bit
+    ///
+    /// See also: [`crate::Response::dragged`].
+    pub fn is_being_dragged(&self, id: Id) -> bool {
+        self.dragged_id() == Some(id)
+    }
 
-  /// This widget just started being dragged this frame.
-  ///
-  /// The same widget should also be found in [`Self::dragged_id`].
-  pub fn drag_started_id(&self) -> Option<Id> {
-    self.interaction_snapshot(|i| i.drag_started)
-  }
+    /// This widget just started being dragged this frame.
+    ///
+    /// The same widget should also be found in [`Self::dragged_id`].
+    pub fn drag_started_id(&self) -> Option<Id> {
+        self.interaction_snapshot(|i| i.drag_started)
+    }
 
-  /// This widget was being dragged, but was released this frame
-  pub fn drag_stopped_id(&self) -> Option<Id> {
-    self.interaction_snapshot(|i| i.drag_stopped)
-  }
+    /// This widget was being dragged, but was released this frame
+    pub fn drag_stopped_id(&self) -> Option<Id> {
+        self.interaction_snapshot(|i| i.drag_stopped)
+    }
 
-  /// Set which widget is being dragged.
-  pub fn set_dragged_id(&self, id: Id) {
-    self.write(|ctx| {
-      let vp = ctx.viewport();
-      let i = &mut vp.interact_widgets;
-      if i.dragged != Some(id) {
-        i.drag_stopped = i.dragged.or(i.drag_stopped);
-        i.dragged = Some(id);
-        i.drag_started = Some(id);
-      }
+    /// Set which widget is being dragged.
+    pub fn set_dragged_id(&self, id: Id) {
+        self.write(|ctx| {
+            let vp = ctx.viewport();
+            let i = &mut vp.interact_widgets;
+            if i.dragged != Some(id) {
+                i.drag_stopped = i.dragged.or(i.drag_stopped);
+                i.dragged = Some(id);
+                i.drag_started = Some(id);
+            }
 
-      ctx.memory.interaction_mut().potential_drag_id = Some(id);
-    });
-  }
+            ctx.memory.interaction_mut().potential_drag_id = Some(id);
+        });
+    }
 
-  /// Stop dragging any widget.
-  pub fn stop_dragging(&self) {
-    self.write(|ctx| {
-      let vp = ctx.viewport();
-      let i = &mut vp.interact_widgets;
-      if i.dragged.is_some() {
-        i.drag_stopped = i.dragged;
-        i.dragged = None;
-      }
+    /// Stop dragging any widget.
+    pub fn stop_dragging(&self) {
+        self.write(|ctx| {
+            let vp = ctx.viewport();
+            let i = &mut vp.interact_widgets;
+            if i.dragged.is_some() {
+                i.drag_stopped = i.dragged;
+                i.dragged = None;
+            }
 
-      ctx.memory.interaction_mut().potential_drag_id = None;
-    });
-  }
+            ctx.memory.interaction_mut().potential_drag_id = None;
+        });
+    }
 
-  /// Is something else being dragged?
-  ///
-  /// Returns true if we are dragging something, but not the given widget.
-  #[inline(always)]
-  pub fn dragging_something_else(&self, not_this: Id) -> bool {
-    let dragged = self.dragged_id();
-    dragged.is_some() && dragged != Some(not_this)
-  }
+    /// Is something else being dragged?
+    ///
+    /// Returns true if we are dragging something, but not the given widget.
+    #[inline(always)]
+    pub fn dragging_something_else(&self, not_this: Id) -> bool {
+        let dragged = self.dragged_id();
+        dragged.is_some() && dragged != Some(not_this)
+    }
 }
 
 #[test]
 fn context_impl_send_sync() {
-  fn assert_send_sync<T: Send + Sync>() {}
-  assert_send_sync::<Context>();
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Context>();
 }

--- a/crates/egui/src/context.rs
+++ b/crates/egui/src/context.rs
@@ -1593,26 +1593,26 @@ impl Context {
 
   /// Useful for pixel-perfect rendering
   #[inline]
-  pub(crate) fn round_to_pixel(&self, point: f32) -> f32 {
+  pub fn round_to_pixel(&self, point: f32) -> f32 {
     let pixels_per_point = self.pixels_per_point();
     (point * pixels_per_point).round() / pixels_per_point
   }
 
   /// Useful for pixel-perfect rendering
   #[inline]
-  pub(crate) fn round_pos_to_pixels(&self, pos: Pos2) -> Pos2 {
+  pub fn round_pos_to_pixels(&self, pos: Pos2) -> Pos2 {
     pos2(self.round_to_pixel(pos.x), self.round_to_pixel(pos.y))
   }
 
   /// Useful for pixel-perfect rendering
   #[inline]
-  pub(crate) fn round_vec_to_pixels(&self, vec: Vec2) -> Vec2 {
+  pub fn round_vec_to_pixels(&self, vec: Vec2) -> Vec2 {
     vec2(self.round_to_pixel(vec.x), self.round_to_pixel(vec.y))
   }
 
   /// Useful for pixel-perfect rendering
   #[inline]
-  pub(crate) fn round_rect_to_pixels(&self, rect: Rect) -> Rect {
+  pub fn round_rect_to_pixels(&self, rect: Rect) -> Rect {
     Rect { min: self.round_pos_to_pixels(rect.min), max: self.round_pos_to_pixels(rect.max) }
   }
 

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -60,14 +60,14 @@ pub struct RawInput {
     /// and/or the pointer (mouse/touch) with [`crate::Context::is_using_pointer`].
     pub events: Vec<Event>,
 
-    /// Dragged files hovering over egui.
-    pub hovered_files: Vec<HoveredFile>,
+    /// Dragged files or strings hovering over egui.
+    pub hovered_items: Vec<HoveredItem>,
 
-    /// Dragged files dropped into egui.
+    /// Dragged files or strings dropped into egui.
     ///
     /// Note: when using `eframe` on Windows you need to enable
     /// drag-and-drop support using `eframe::NativeOptions`.
-    pub dropped_files: Vec<DroppedFile>,
+    pub dropped_items: Vec<DroppedItem>,
 
     /// The native window has the keyboard focus (i.e. is receiving key presses).
     ///
@@ -86,8 +86,8 @@ impl Default for RawInput {
             predicted_dt: 1.0 / 60.0,
             modifiers: Modifiers::default(),
             events: vec![],
-            hovered_files: Default::default(),
-            dropped_files: Default::default(),
+            hovered_items: Default::default(),
+            dropped_items: Default::default(),
             focused: true, // integrations opt into global focus tracking
         }
     }
@@ -102,8 +102,8 @@ impl RawInput {
 
     /// Helper: move volatile (deltas and events), clone the rest.
     ///
-    /// * [`Self::hovered_files`] is cloned.
-    /// * [`Self::dropped_files`] is moved.
+    /// * [`Self::hovered_items`] is cloned.
+    /// * [`Self::dropped_items`] is moved.
     pub fn take(&mut self) -> Self {
         Self {
             viewport_id: self.viewport_id,
@@ -114,8 +114,8 @@ impl RawInput {
             predicted_dt: self.predicted_dt,
             modifiers: self.modifiers,
             events: std::mem::take(&mut self.events),
-            hovered_files: self.hovered_files.clone(),
-            dropped_files: std::mem::take(&mut self.dropped_files),
+            hovered_items: self.hovered_items.clone(),
+            dropped_items: std::mem::take(&mut self.dropped_items),
             focused: self.focused,
         }
     }
@@ -131,8 +131,8 @@ impl RawInput {
             predicted_dt,
             modifiers,
             mut events,
-            mut hovered_files,
-            mut dropped_files,
+            mut hovered_items,
+            mut dropped_items,
             focused,
         } = newer;
 
@@ -144,8 +144,8 @@ impl RawInput {
         self.predicted_dt = predicted_dt; // use latest dt
         self.modifiers = modifiers; // use latest
         self.events.append(&mut events);
-        self.hovered_files.append(&mut hovered_files);
-        self.dropped_files.append(&mut dropped_files);
+        self.hovered_items.append(&mut hovered_items);
+        self.dropped_items.append(&mut dropped_items);
         self.focused = focused;
     }
 }
@@ -308,6 +308,22 @@ impl ViewportInfo {
     }
 }
 
+/// A File or String about to be dropped into egui.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum HoveredItem {
+    String(HoveredString),
+    File(HoveredFile),
+}
+
+/// A string about to be dropped into egui.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct HoveredString {
+    /// With the `eframe` web backend, this is set to the mime-type of the string (if available).
+    pub mime: String,
+}
+
 /// A file about to be dropped into egui.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -317,6 +333,25 @@ pub struct HoveredFile {
 
     /// With the `eframe` web backend, this is set to the mime-type of the file (if available).
     pub mime: String,
+}
+
+/// A file or string dropped into egui.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum DroppedItem {
+    String(DroppedString),
+    File(DroppedFile),
+}
+
+/// A string dropped into egui.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct DroppedString {
+    /// With the `eframe` web backend, this is set to the mime-type of the string (if available).
+    pub mime: String,
+
+    /// The contents of the string itself.
+    pub contents: String,
 }
 
 /// A file dropped into egui.
@@ -1041,8 +1076,8 @@ impl RawInput {
             predicted_dt,
             modifiers,
             events,
-            hovered_files,
-            dropped_files,
+            hovered_items,
+            dropped_items,
             focused,
         } = self;
 
@@ -1065,8 +1100,8 @@ impl RawInput {
         }
         ui.label(format!("predicted_dt: {:.1} ms", 1e3 * predicted_dt));
         ui.label(format!("modifiers: {modifiers:#?}"));
-        ui.label(format!("hovered_files: {}", hovered_files.len()));
-        ui.label(format!("dropped_files: {}", dropped_files.len()));
+        ui.label(format!("hovered_items: {}", hovered_items.len()));
+        ui.label(format!("dropped_files: {}", dropped_items.len()));
         ui.label(format!("focused: {focused}"));
         ui.scope(|ui| {
             ui.set_min_height(150.0);

--- a/crates/egui/src/data/input.rs
+++ b/crates/egui/src/data/input.rs
@@ -69,6 +69,10 @@ pub struct RawInput {
     /// drag-and-drop support using `eframe::NativeOptions`.
     pub dropped_items: Vec<DroppedItem>,
 
+    /// MEMBRANE: True for one frame while handling the dragstart DOM event. The app must set native_drag_payoad on this
+    /// frame so it can be picked up by the browser.
+    pub native_drag_starting: bool,
+
     /// The native window has the keyboard focus (i.e. is receiving key presses).
     ///
     /// False when the user alt-tab away from the application, for instance.
@@ -88,6 +92,7 @@ impl Default for RawInput {
             events: vec![],
             hovered_items: Default::default(),
             dropped_items: Default::default(),
+            native_drag_starting: false,
             focused: true, // integrations opt into global focus tracking
         }
     }
@@ -116,6 +121,7 @@ impl RawInput {
             events: std::mem::take(&mut self.events),
             hovered_items: self.hovered_items.clone(),
             dropped_items: std::mem::take(&mut self.dropped_items),
+            native_drag_starting: self.native_drag_starting,
             focused: self.focused,
         }
     }
@@ -133,6 +139,7 @@ impl RawInput {
             mut events,
             mut hovered_items,
             mut dropped_items,
+            native_drag_starting,
             focused,
         } = newer;
 
@@ -146,6 +153,7 @@ impl RawInput {
         self.events.append(&mut events);
         self.hovered_items.append(&mut hovered_items);
         self.dropped_items.append(&mut dropped_items);
+        self.native_drag_starting = native_drag_starting;
         self.focused = focused;
     }
 }
@@ -1078,6 +1086,7 @@ impl RawInput {
             events,
             hovered_items,
             dropped_items,
+            native_drag_starting,
             focused,
         } = self;
 
@@ -1102,6 +1111,7 @@ impl RawInput {
         ui.label(format!("modifiers: {modifiers:#?}"));
         ui.label(format!("hovered_items: {}", hovered_items.len()));
         ui.label(format!("dropped_files: {}", dropped_items.len()));
+        ui.label(format!("native_drag_starting: {}", native_drag_starting));
         ui.label(format!("focused: {focused}"));
         ui.scope(|ui| {
             ui.set_min_height(150.0);

--- a/crates/egui/src/data/output.rs
+++ b/crates/egui/src/data/output.rs
@@ -118,6 +118,9 @@ pub struct PlatformOutput {
     /// Useful for IME.
     pub ime: Option<IMEOutput>,
 
+    /// MEMBRANE: Support dragging things natively outside of the canvas.
+    pub native_drag_payload: Option<String>,
+
     /// The difference in the widget tree since last frame.
     ///
     /// NOTE: this needs to be per-viewport.
@@ -153,6 +156,7 @@ impl PlatformOutput {
             mut events,
             mutable_text_under_cursor,
             ime,
+            native_drag_payload,
             #[cfg(feature = "accesskit")]
             accesskit_update,
         } = newer;
@@ -167,6 +171,7 @@ impl PlatformOutput {
         self.events.append(&mut events);
         self.mutable_text_under_cursor = mutable_text_under_cursor;
         self.ime = ime.or(self.ime);
+        self.native_drag_payload = native_drag_payload;
 
         #[cfg(feature = "accesskit")]
         {

--- a/crates/egui/src/lib.rs
+++ b/crates/egui/src/lib.rs
@@ -455,7 +455,7 @@ pub use {
     drag_and_drop::DragAndDrop,
     epaint::text::TextWrapMode,
     grid::Grid,
-    id::{Id, IdMap},
+    id::{Id, IdMap, IdSet},
     input_state::{InputState, MultiTouchInfo, PointerState},
     layers::{LayerId, Order},
     layout::*,

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -964,6 +964,10 @@ impl Areas {
         self.areas.get(&id)
     }
 
+    pub fn remove(&mut self, id: Id) {
+        self.areas.remove(&id);
+    }
+
     pub fn get_mut(&mut self, id: Id) -> Option<&mut area::State> {
         self.areas.get_mut(&id)
     }

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -708,7 +708,7 @@ impl Memory {
     }
 
     /// True if the given widget had keyboard focus last frame, but not this one.
-    pub(crate) fn lost_focus(&self, id: Id) -> bool {
+    pub fn lost_focus(&self, id: Id) -> bool {
         self.had_focus_last_frame(id) && !self.has_focus(id)
     }
 

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -964,6 +964,10 @@ impl Areas {
         self.areas.get(&id)
     }
 
+    pub fn get_mut(&mut self, id: Id) -> Option<&mut area::State> {
+        self.areas.get_mut(&id)
+    }
+
     /// Back-to-front. Top is last.
     pub(crate) fn order(&self) -> &[LayerId] {
         &self.order

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -985,7 +985,7 @@ impl Areas {
         self.areas.len()
     }
 
-    pub(crate) fn get(&self, id: Id) -> Option<&area::AreaState> {
+    pub fn get(&self, id: Id) -> Option<&area::AreaState> {
         self.areas.get(&id)
     }
 
@@ -993,7 +993,7 @@ impl Areas {
         self.areas.remove(&id);
     }
 
-    pub fn get_mut(&mut self, id: Id) -> Option<&mut area::State> {
+    pub fn get_mut(&mut self, id: Id) -> Option<&mut area::AreaState> {
         self.areas.get_mut(&id)
     }
 

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -87,10 +87,14 @@ pub struct Memory {
     everything_is_visible: bool,
 
     /// Transforms per layer
+    // MEMBRANE: don't persist area state
+    #[cfg_attr(feature = "persistence", serde(skip))]
     pub layer_transforms: HashMap<LayerId, TSTransform>,
 
     // -------------------------------------------------
     // Per-viewport:
+    // MEMBRANE: don't persist area state
+    #[cfg_attr(feature = "persistence", serde(skip))]
     areas: ViewportIdMap<Areas>,
 
     #[cfg_attr(feature = "persistence", serde(skip))]

--- a/crates/egui/src/memory.rs
+++ b/crates/egui/src/memory.rs
@@ -2,6 +2,7 @@
 
 use ahash::{HashMap, HashSet};
 use epaint::emath::TSTransform;
+use std::sync::atomic::AtomicBool;
 
 use crate::{
     area, vec2, EventFilter, Id, IdMap, LayerId, Order, Pos2, Rangef, RawInput, Rect, Style, Vec2,
@@ -80,8 +81,10 @@ pub struct Memory {
 
     /// Which popup-window is open (if any)?
     /// Could be a combo box, color picker, menu etc.
+    /// The bool is used to detect if a popup was abandoned, that way we can reset `popup` back
+    /// to `None` at the end of the frame.
     #[cfg_attr(feature = "persistence", serde(skip))]
-    popup: Option<Id>,
+    popup: Option<(Id, std::sync::Arc<AtomicBool>)>,
 
     #[cfg_attr(feature = "persistence", serde(skip))]
     everything_is_visible: bool,
@@ -679,6 +682,13 @@ impl Memory {
         self.caches.update();
         self.areas_mut().end_frame();
         self.focus_mut().end_frame(used_ids);
+
+        if let Some((_id, retained)) = &mut self.popup {
+            let retained = retained.fetch_and(false, std::sync::atomic::Ordering::SeqCst);
+            if !retained {
+                self.popup = None;
+            }
+        }
     }
 
     pub(crate) fn set_viewport_id(&mut self, viewport_id: ViewportId) {
@@ -881,7 +891,18 @@ impl Memory {
 impl Memory {
     /// Is the given popup open?
     pub fn is_popup_open(&self, popup_id: Id) -> bool {
-        self.popup == Some(popup_id) || self.everything_is_visible()
+        if self.everything_is_visible() {
+            return true;
+        }
+        if let Some((id, retained)) = &self.popup {
+            let is_open = *id == popup_id;
+            if is_open {
+                retained.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+            is_open
+        } else {
+            false
+        }
     }
 
     /// Is any popup open?
@@ -891,7 +912,7 @@ impl Memory {
 
     /// Open the given popup, and close all other.
     pub fn open_popup(&mut self, popup_id: Id) {
-        self.popup = Some(popup_id);
+        self.popup = Some((popup_id, std::sync::Arc::new(true.into())));
     }
 
     /// Close the open popup, if any.

--- a/crates/egui/src/menu.rs
+++ b/crates/egui/src/menu.rs
@@ -210,6 +210,15 @@ fn menu_popup<'c, R>(
         area_rect
     };
 
+    // MEMBRANE: close any menu when the app loses focus
+    let lost_focus = ctx.input(|i| {
+        i.events
+            .iter()
+            .any(|e| matches!(e, Event::WindowFocused(false)))
+    });
+    if lost_focus {
+        menu_state_arc.write().response = MenuResponse::Close;
+    }
     area_response
 }
 

--- a/crates/egui/src/painter.rs
+++ b/crates/egui/src/painter.rs
@@ -158,7 +158,19 @@ impl Painter {
         self.clip_rect = clip_rect;
     }
 
-    /// Useful for pixel-perfect rendering.
+    /// Useful for pixel-perfect rendering of strokes.
+    #[inline]
+    pub fn round_to_pixel_center(&self, point: f32) -> f32 {
+        self.ctx().round_to_pixel_center(point)
+    }
+
+    /// Useful for pixel-perfect rendering of strokes.
+    #[inline]
+    pub fn round_pos_to_pixel_center(&self, pos: Pos2) -> Pos2 {
+        self.ctx().round_pos_to_pixel_center(pos)
+    }
+
+    /// Useful for pixel-perfect rendering of filled shapes.
     #[inline]
     pub fn round_to_pixel(&self, point: f32) -> f32 {
         self.ctx().round_to_pixel(point)

--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -341,6 +341,12 @@ impl Response {
         self.drag_started() && self.ctx.input(|i| i.pointer.button_down(button))
     }
 
+    /// MEMBRANE: Is a native drag starting on this widget?
+    #[inline]
+    pub fn native_drag_started(&self) -> bool {
+        self.hovered() && self.ctx.input(|i| i.raw.native_drag_starting)
+    }
+
     /// The widget is being dragged.
     ///
     /// To find out which button(s), use [`Self::dragged_by`].

--- a/crates/egui/src/style.rs
+++ b/crates/egui/src/style.rs
@@ -2367,8 +2367,12 @@ impl Widget for &mut Stroke {
 
             // stroke preview:
             let (_id, stroke_rect) = ui.allocate_space(ui.spacing().interact_size);
-            let left = stroke_rect.left_center();
-            let right = stroke_rect.right_center();
+            let left = ui
+                .painter()
+                .round_pos_to_pixel_center(stroke_rect.left_center());
+            let right = ui
+                .painter()
+                .round_pos_to_pixel_center(stroke_rect.right_center());
             ui.painter().line_segment([left, right], (*width, *color));
         })
         .response

--- a/crates/egui/src/ui.rs
+++ b/crates/egui/src/ui.rs
@@ -2074,9 +2074,9 @@ impl Ui {
 
             let stroke = self.visuals().widgets.noninteractive.bg_stroke;
             let left_top = child_rect.min - 0.5 * indent * Vec2::X;
-            let left_top = self.painter().round_pos_to_pixels(left_top);
+            let left_top = self.painter().round_pos_to_pixel_center(left_top);
             let left_bottom = pos2(left_top.x, child_ui.min_rect().bottom() - 2.0);
-            let left_bottom = self.painter().round_pos_to_pixels(left_bottom);
+            let left_bottom = self.painter().round_pos_to_pixel_center(left_bottom);
 
             if left_vline {
                 // draw a faint line on the left to mark the indented section

--- a/crates/egui/src/util/id_type_map.rs
+++ b/crates/egui/src/util/id_type_map.rs
@@ -483,6 +483,13 @@ impl IdTypeMap {
         self.map.remove(&hash);
     }
 
+    /// Returns true if the give id is contained in the map
+    #[inline]
+    pub fn contains<T: 'static>(&mut self, id: Id) -> bool {
+        let hash = hash(TypeId::of::<T>(), id);
+        self.map.contains_key(&hash)
+    }
+
     /// Remove and fetch the state of this type and id.
     #[inline]
     pub fn remove_temp<T: 'static + Default>(&mut self, id: Id) -> Option<T> {

--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -24,6 +24,7 @@ use self::text_selection::LabelSelectionState;
 pub struct Label {
     text: WidgetText,
     wrap_mode: Option<TextWrapMode>,
+    tooltip: bool,
     sense: Option<Sense>,
     selectable: Option<bool>,
 }
@@ -33,6 +34,7 @@ impl Label {
         Self {
             text: text.into(),
             wrap_mode: None,
+            tooltip: true,
             sense: None,
             selectable: None,
         }
@@ -73,6 +75,16 @@ impl Label {
     #[inline]
     pub fn extend(mut self) -> Self {
         self.wrap_mode = Some(TextWrapMode::Extend);
+        self
+    }
+
+    /// If `true` and the label's text got elided, the full text will be
+    /// shown on hover as a tool-tip.
+    ///
+    /// Default is `true`.
+    #[inline]
+    pub fn tooltip(mut self, tooltip: bool) -> Self {
+        self.tooltip = tooltip;
         self
     }
 
@@ -235,13 +247,14 @@ impl Widget for Label {
         let interactive = self.sense.map_or(false, |sense| sense != Sense::hover());
 
         let selectable = self.selectable;
+        let tooltip = self.tooltip;
 
         let (galley_pos, galley, mut response) = self.layout_in_ui(ui);
         response
             .widget_info(|| WidgetInfo::labeled(WidgetType::Label, ui.is_enabled(), galley.text()));
 
         if ui.is_rect_visible(response.rect) {
-            if galley.elided {
+            if tooltip && galley.elided {
                 // Show the full (non-elided) text on hover:
                 response = response.on_hover_text(galley.text());
             }

--- a/crates/egui/src/widgets/separator.rs
+++ b/crates/egui/src/widgets/separator.rs
@@ -116,12 +116,12 @@ impl Widget for Separator {
             if is_horizontal_line {
                 painter.hline(
                     (rect.left() - grow)..=(rect.right() + grow),
-                    painter.round_to_pixel(rect.center().y),
+                    painter.round_to_pixel_center(rect.center().y),
                     stroke,
                 );
             } else {
                 painter.vline(
-                    painter.round_to_pixel(rect.center().x),
+                    painter.round_to_pixel_center(rect.center().x),
                     (rect.top() - grow)..=(rect.bottom() + grow),
                     stroke,
                 );

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -425,7 +425,9 @@ impl<'t> TextEdit<'t> {
                         frame_rect,
                         visuals.rounding,
                         ui.visuals().extreme_bg_color,
-                        visuals.bg_stroke, // TODO(emilk): we want to show something here, or a text-edit field doesn't "pop".
+                        // visuals.bg_stroke, // TODO(emilk): we want to show something here, or a text-edit field doesn't "pop".
+                        // MEMBRANE: Use a dim version of the selection color which is used for the active stroke
+                        Stroke::new(1.0, ui.visuals().selection.stroke.color.gamma_multiply(0.2)),
                     )
                 }
             } else {

--- a/crates/egui_demo_app/src/apps/custom3d_glow.rs
+++ b/crates/egui_demo_app/src/apps/custom3d_glow.rs
@@ -65,6 +65,7 @@ impl Custom3d {
 
         let cb = egui_glow::CallbackFn::new(move |_info, painter| {
             rotating_triangle.lock().paint(painter.gl(), angle);
+            true
         });
 
         let callback = egui::PaintCallback {

--- a/crates/egui_demo_app/src/wrap_app.rs
+++ b/crates/egui_demo_app/src/wrap_app.rs
@@ -277,12 +277,14 @@ impl eframe::App for WrapApp {
         }
 
         let mut cmd = Command::Nothing;
-        egui::TopBottomPanel::top("wrap_app_top_bar").show(ctx, |ui| {
-            ui.horizontal_wrapped(|ui| {
-                ui.visuals_mut().button_frame = false;
-                self.bar_contents(ui, frame, &mut cmd);
+        egui::TopBottomPanel::top("wrap_app_top_bar")
+            .frame(egui::Frame::none().inner_margin(4.0))
+            .show(ctx, |ui| {
+                ui.horizontal_wrapped(|ui| {
+                    ui.visuals_mut().button_frame = false;
+                    self.bar_contents(ui, frame, &mut cmd);
+                });
             });
-        });
 
         self.state.backend_panel.update(ctx, frame);
 
@@ -324,6 +326,7 @@ impl WrapApp {
         egui::SidePanel::left("backend_panel")
             .resizable(false)
             .show_animated(ctx, is_open, |ui| {
+                ui.add_space(4.0);
                 ui.vertical_centered(|ui| {
                     ui.heading("💻 Backend");
                 });

--- a/crates/egui_demo_lib/src/demo/demo_app_windows.rs
+++ b/crates/egui_demo_lib/src/demo/demo_app_windows.rs
@@ -260,6 +260,7 @@ impl DemoWindows {
             .resizable(false)
             .default_width(150.0)
             .show(ctx, |ui| {
+                ui.add_space(4.0);
                 ui.vertical_centered(|ui| {
                     ui.heading("✒ egui demos");
                 });

--- a/crates/egui_demo_lib/src/rendering_test.rs
+++ b/crates/egui_demo_lib/src/rendering_test.rs
@@ -412,6 +412,49 @@ pub fn pixel_test(ui: &mut Ui) {
     ui.add_space(4.0);
 
     pixel_test_squares(ui);
+
+    ui.add_space(4.0);
+
+    pixel_test_strokes(ui);
+}
+
+fn pixel_test_strokes(ui: &mut Ui) {
+    ui.label("The strokes should align to the physical pixel grid.");
+    let color = if ui.style().visuals.dark_mode {
+        egui::Color32::WHITE
+    } else {
+        egui::Color32::BLACK
+    };
+
+    let pixels_per_point = ui.ctx().pixels_per_point();
+
+    for thickness_pixels in 1..=3 {
+        let thickness_pixels = thickness_pixels as f32;
+        let thickness_points = thickness_pixels / pixels_per_point;
+        let num_squares = (pixels_per_point * 10.0).round().max(10.0) as u32;
+        let size_pixels = vec2(
+            ui.available_width(),
+            num_squares as f32 + thickness_pixels * 2.0,
+        );
+        let size_points = size_pixels / pixels_per_point + Vec2::splat(2.0);
+        let (response, painter) = ui.allocate_painter(size_points, Sense::hover());
+
+        let mut cursor_pixel = Pos2::new(
+            response.rect.min.x * pixels_per_point + thickness_pixels,
+            response.rect.min.y * pixels_per_point + thickness_pixels,
+        )
+        .ceil();
+
+        let stroke = Stroke::new(thickness_points, color);
+        for size in 1..=num_squares {
+            let rect_points = Rect::from_min_size(
+                Pos2::new(cursor_pixel.x, cursor_pixel.y),
+                Vec2::splat(size as f32),
+            );
+            painter.rect_stroke(rect_points / pixels_per_point, 0.0, stroke);
+            cursor_pixel.x += (1 + size) as f32 + thickness_pixels * 2.0;
+        }
+    }
 }
 
 fn pixel_test_squares(ui: &mut Ui) {

--- a/crates/egui_extras/src/loaders/ehttp_loader.rs
+++ b/crates/egui_extras/src/loaders/ehttp_loader.rs
@@ -60,9 +60,10 @@ impl BytesLoader for EhttpLoader {
     }
 
     fn load(&self, ctx: &egui::Context, uri: &str) -> BytesLoadResult {
-        if !starts_with_one_of(uri, PROTOCOLS) {
-            return Err(LoadError::NotSupported);
-        }
+        // MEMBRANE: this check was disabled so we can load relative URLs
+        // if !starts_with_one_of(uri, PROTOCOLS) {
+        //     return Err(LoadError::NotSupported);
+        // }
 
         let mut cache = self.cache.lock();
         if let Some(entry) = cache.get(uri).cloned() {

--- a/crates/egui_extras/src/syntax_highlighting.rs
+++ b/crates/egui_extras/src/syntax_highlighting.rs
@@ -216,7 +216,7 @@ impl CodeTheme {
             formats: enum_map::enum_map![
                 TokenType::Comment => TextFormat::simple(font_id.clone(), Color32::from_gray(120)),
                 TokenType::Keyword => TextFormat::simple(font_id.clone(), Color32::from_rgb(255, 100, 100)),
-                TokenType::Literal => TextFormat::simple(font_id.clone(), Color32::from_rgb(87, 165, 171)),
+                TokenType::Literal => TextFormat::simple(font_id.clone(), Color32::from_rgb(240, 240, 240)),
                 TokenType::StringLiteral => TextFormat::simple(font_id.clone(), Color32::from_rgb(109, 147, 226)),
                 TokenType::Punctuation => TextFormat::simple(font_id.clone(), Color32::LIGHT_GRAY),
                 TokenType::Whitespace => TextFormat::simple(font_id.clone(), Color32::TRANSPARENT),
@@ -447,6 +447,13 @@ impl Highlighter {
                     theme.formats[TokenType::StringLiteral].clone(),
                 );
                 text = &text[end..];
+            } else if text.starts_with(|c: char| c.is_ascii_digit()) {
+                let end = text[1..]
+                    .find(|c: char| !c.is_ascii_digit())
+                    .map_or_else(|| text.len(), |i| i + 1);
+                let word = &text[..end];
+                job.append(word, 0.0, theme.formats[TokenType::StringLiteral].clone());
+                text = &text[end..];
             } else if text.starts_with(|c: char| c.is_ascii_alphanumeric()) {
                 let end = text[1..]
                     .find(|c: char| !c.is_ascii_alphanumeric())
@@ -504,6 +511,7 @@ impl Language {
             "c" | "h" | "hpp" | "cpp" | "c++" => Some(Self::cpp()),
             "py" | "python" => Some(Self::python()),
             "rs" | "rust" => Some(Self::rust()),
+            "ts" | "typescript" => Some(Self::typescript()),
             "toml" => Some(Self::toml()),
             _ => {
                 None // unsupported language
@@ -617,6 +625,79 @@ impl Language {
                 "while",
                 "xor_eq",
                 "xor",
+            ]
+            .into_iter()
+            .collect(),
+        }
+    }
+
+    fn typescript() -> Self {
+        Self {
+            double_slash_comments: true,
+            hash_comments: false,
+            keywords: [
+                "await",
+                "async",
+                "break",
+                "case",
+                "catch",
+                "class",
+                "const",
+                "continue",
+                "debugger",
+                "default",
+                "delete",
+                "do",
+                "else",
+                "enum",
+                "export",
+                "extends",
+                "false",
+                "finally",
+                "for",
+                "function",
+                "if",
+                "import",
+                "in",
+                "instanceof",
+                "new",
+                "null",
+                "return",
+                "super",
+                "switch",
+                "this",
+                "throw",
+                "true",
+                "try",
+                "typeof",
+                "var",
+                "void",
+                "while",
+                "with",
+                "as",
+                "implements",
+                "interface",
+                "let",
+                "package",
+                "private",
+                "protected",
+                "public",
+                "static",
+                "yield",
+                "any",
+                "boolean",
+                "constructor",
+                "declare",
+                "get",
+                "module",
+                "require",
+                "number",
+                "set",
+                "string",
+                "symbol",
+                "type",
+                "from",
+                "of",
             ]
             .into_iter()
             .collect(),

--- a/crates/egui_extras/src/syntax_highlighting.rs
+++ b/crates/egui_extras/src/syntax_highlighting.rs
@@ -42,7 +42,7 @@ pub fn highlight(ctx: &egui::Context, theme: &CodeTheme, code: &str, language: &
 #[cfg(not(feature = "syntect"))]
 #[derive(Clone, Copy, PartialEq, enum_map::Enum)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-enum TokenType {
+pub enum TokenType {
     Comment,
     Keyword,
     Literal,
@@ -130,7 +130,7 @@ pub struct CodeTheme {
     syntect_theme: SyntectTheme,
 
     #[cfg(not(feature = "syntect"))]
-    formats: enum_map::EnumMap<TokenType, egui::TextFormat>,
+    pub formats: enum_map::EnumMap<TokenType, egui::TextFormat>,
 }
 
 impl Default for CodeTheme {

--- a/crates/emath/src/align.rs
+++ b/crates/emath/src/align.rs
@@ -50,6 +50,14 @@ impl Align {
         }
     }
 
+    pub fn opposite(self) -> Self {
+        match self {
+            Self::Min => Self::Max,
+            Self::Center => Self::Center,
+            Self::Max => Self::Min,
+        }
+    }
+
     /// Returns a range of given size within a specified range.
     ///
     /// If the requested `size` is bigger than the size of `range`, then the returned
@@ -168,6 +176,10 @@ impl Align2 {
     /// -1, 0, or +1 for each axis
     pub fn to_sign(self) -> Vec2 {
         vec2(self.x().to_sign(), self.y().to_sign())
+    }
+
+    pub fn opposite(self) -> Align2 {
+        Align2([self.x().opposite(), self.y().opposite()])
     }
 
     /// Used e.g. to anchor a piece of text to a part of the rectangle.

--- a/crates/emath/src/rect.rs
+++ b/crates/emath/src/rect.rs
@@ -269,6 +269,35 @@ impl Rect {
         *self = self.translate(center - self.center());
     }
 
+    /// Sets the corner of the rectangle to the given position.
+    pub fn set_corner(&mut self, pos: Pos2, corner: Align2) {
+        for i in [0, 1] {
+            match corner[i] {
+                Align::Min => self.min[i] = pos[i],
+                Align::Max => self.max[i] = pos[i],
+                Align::Center => {
+                    self.min[i] = pos[i] - self.size()[i] / 2.0;
+                }
+            }
+        }
+    }
+
+    /// Sets the size while keeping the anchored corner fixed.
+    pub fn set_size_with_anchor(&mut self, vec: Vec2, anchor: Align2) {
+        for i in [0, 1] {
+            match anchor[i] {
+                Align::Min => self.max[i] = self.min[i] + vec[i],
+                Align::Max => self.min[i] = self.max[i] - vec[i],
+                Align::Center => {
+                    let half = vec[i] / 2.0;
+                    let center = (self.min[i] + self.max[i]) / 2.0;
+                    self.min[i] = center - half;
+                    self.max[i] = center + half;
+                }
+            }
+        }
+    }
+
     #[must_use]
     #[inline(always)]
     pub fn contains(&self, p: Pos2) -> bool {

--- a/crates/epaint/Cargo.toml
+++ b/crates/epaint/Cargo.toml
@@ -100,6 +100,11 @@ serde = { workspace = true, optional = true, features = ["derive", "rc"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = { workspace = true, optional = true }
 
+# web:
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { workspace = true, features = ["console"] }
+wasm-bindgen.workspace = true
+
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/epaint/src/stroke.rs
+++ b/crates/epaint/src/stroke.rs
@@ -55,6 +55,20 @@ impl std::hash::Hash for Stroke {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub(crate) enum StrokeKind {
+    Outside,
+    Inside,
+    Middle,
+}
+
+impl Default for StrokeKind {
+    fn default() -> Self {
+        Self::Middle
+    }
+}
+
 /// Describes the width and color of paths. The color can either be solid or provided by a callback. For more information, see [`ColorMode`]
 ///
 /// The default stroke is the same as [`Stroke::NONE`].
@@ -63,6 +77,7 @@ impl std::hash::Hash for Stroke {
 pub struct PathStroke {
     pub width: f32,
     pub color: ColorMode,
+    pub(crate) kind: StrokeKind,
 }
 
 impl PathStroke {
@@ -70,6 +85,7 @@ impl PathStroke {
     pub const NONE: Self = Self {
         width: 0.0,
         color: ColorMode::TRANSPARENT,
+        kind: StrokeKind::Middle,
     };
 
     #[inline]
@@ -77,6 +93,7 @@ impl PathStroke {
         Self {
             width: width.into(),
             color: ColorMode::Solid(color.into()),
+            kind: StrokeKind::default(),
         }
     }
 
@@ -91,6 +108,28 @@ impl PathStroke {
         Self {
             width: width.into(),
             color: ColorMode::UV(Arc::new(callback)),
+            kind: StrokeKind::default(),
+        }
+    }
+
+    pub fn middle(self) -> Self {
+        Self {
+            kind: StrokeKind::Middle,
+            ..self
+        }
+    }
+
+    pub fn outside(self) -> Self {
+        Self {
+            kind: StrokeKind::Outside,
+            ..self
+        }
+    }
+
+    pub fn inside(self) -> Self {
+        Self {
+            kind: StrokeKind::Inside,
+            ..self
         }
     }
 
@@ -116,6 +155,7 @@ impl From<Stroke> for PathStroke {
         Self {
             width: value.width,
             color: ColorMode::Solid(value.color),
+            kind: StrokeKind::default(),
         }
     }
 }

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -1714,7 +1714,7 @@ impl Tessellator {
         }
 
         if galley.pixels_per_point != self.pixels_per_point {
-            eprintln!("epaint: WARNING: pixels_per_point (dpi scale) have changed between text layout and tessellation. \
+            log::warn!("epaint: WARNING: pixels_per_point (dpi scale) have changed between text layout and tessellation. \
                        You must recreate your text shapes if pixels_per_point changes.");
         }
 

--- a/crates/epaint/src/tessellator.rs
+++ b/crates/epaint/src/tessellator.rs
@@ -532,8 +532,6 @@ pub mod path {
         let r = clamp_rounding(rounding, rect);
 
         if r == Rounding::ZERO {
-            let min = rect.min;
-            let max = rect.max;
             path.reserve(4);
             path.push(pos2(min.x, min.y)); // left top
             path.push(pos2(max.x, min.y)); // right top
@@ -868,6 +866,21 @@ fn fill_closed_path_with_uv(
     }
 }
 
+/// Translate a point according to the stroke kind.
+fn translate_stroke_point(p: &PathPoint, stroke: &PathStroke) -> PathPoint {
+    match stroke.kind {
+        stroke::StrokeKind::Middle => p.clone(),
+        stroke::StrokeKind::Outside => PathPoint {
+            pos: p.pos + p.normal * stroke.width * 0.5,
+            normal: p.normal,
+        },
+        stroke::StrokeKind::Inside => PathPoint {
+            pos: p.pos - p.normal * stroke.width * 0.5,
+            normal: p.normal,
+        },
+    }
+}
+
 /// Tessellate the given path as a stroke with thickness.
 fn stroke_path(
     feathering: f32,
@@ -885,8 +898,13 @@ fn stroke_path(
     let idx = out.vertices.len() as u32;
 
     // expand the bounding box to include the thickness of the path
-    let bbox = Rect::from_points(&path.iter().map(|p| p.pos).collect::<Vec<Pos2>>())
-        .expand((stroke.width / 2.0) + feathering);
+    let bbox = Rect::from_points(
+        &path
+            .iter()
+            .map(|p| translate_stroke_point(p, stroke).pos)
+            .collect::<Vec<Pos2>>(),
+    )
+    .expand((stroke.width / 2.0) + feathering);
 
     let get_color = |col: &ColorMode, pos: Pos2| match col {
         ColorMode::Solid(col) => *col,
@@ -920,7 +938,7 @@ fn stroke_path(
             let mut i0 = n - 1;
             for i1 in 0..n {
                 let connect_with_previous = path_type == PathType::Closed || i1 > 0;
-                let p1 = &path[i1 as usize];
+                let p1 = translate_stroke_point(&path[i1 as usize], stroke);
                 let p = p1.pos;
                 let n = p1.normal;
                 out.colored_vertex(p + n * feathering, color_outer);
@@ -962,7 +980,7 @@ fn stroke_path(
 
                     let mut i0 = n - 1;
                     for i1 in 0..n {
-                        let p1 = &path[i1 as usize];
+                        let p1 = translate_stroke_point(&path[i1 as usize], stroke);
                         let p = p1.pos;
                         let n = p1.normal;
                         out.colored_vertex(p + n * outer_rad, color_outer);
@@ -1007,7 +1025,7 @@ fn stroke_path(
                     out.reserve_vertices(4 * n as usize);
 
                     {
-                        let end = &path[0];
+                        let end = translate_stroke_point(&path[0], stroke);
                         let p = end.pos;
                         let n = end.normal;
                         let back_extrude = n.rot90() * feathering;
@@ -1028,7 +1046,7 @@ fn stroke_path(
 
                     let mut i0 = 0;
                     for i1 in 1..n - 1 {
-                        let point = &path[i1 as usize];
+                        let point = translate_stroke_point(&path[i1 as usize], stroke);
                         let p = point.pos;
                         let n = point.normal;
                         out.colored_vertex(p + n * outer_rad, color_outer);
@@ -1056,7 +1074,7 @@ fn stroke_path(
 
                     {
                         let i1 = n - 1;
-                        let end = &path[i1 as usize];
+                        let end = translate_stroke_point(&path[i1 as usize], stroke);
                         let p = end.pos;
                         let n = end.normal;
                         let back_extrude = -n.rot90() * feathering;
@@ -1120,7 +1138,7 @@ fn stroke_path(
                     return;
                 }
             }
-            for p in path {
+            for p in path.iter().map(|p| translate_stroke_point(p, stroke)) {
                 out.colored_vertex(
                     p.pos + radius * p.normal,
                     mul_color(
@@ -1138,7 +1156,7 @@ fn stroke_path(
             }
         } else {
             let radius = stroke.width / 2.0;
-            for p in path {
+            for p in path.iter().map(|p| translate_stroke_point(p, stroke)) {
                 out.colored_vertex(
                     p.pos + radius * p.normal,
                     get_color(&stroke.color, p.pos + radius * p.normal),
@@ -1403,8 +1421,11 @@ impl Tessellator {
         self.scratchpad_path.clear();
         self.scratchpad_path.add_circle(center, radius);
         self.scratchpad_path.fill(self.feathering, fill, out);
-        self.scratchpad_path
-            .stroke_closed(self.feathering, &stroke.into(), out);
+        self.scratchpad_path.stroke_closed(
+            self.feathering,
+            &PathStroke::from(stroke).outside(),
+            out,
+        );
     }
 
     /// Tessellate a single [`EllipseShape`] into a [`Mesh`].
@@ -1470,8 +1491,11 @@ impl Tessellator {
         self.scratchpad_path.clear();
         self.scratchpad_path.add_line_loop(&points);
         self.scratchpad_path.fill(self.feathering, fill, out);
-        self.scratchpad_path
-            .stroke_closed(self.feathering, &stroke.into(), out);
+        self.scratchpad_path.stroke_closed(
+            self.feathering,
+            &PathStroke::from(stroke).outside(),
+            out,
+        );
     }
 
     /// Tessellate a single [`Mesh`] into a [`Mesh`].
@@ -1661,7 +1685,7 @@ impl Tessellator {
                 path.fill(self.feathering, fill, out);
             }
 
-            path.stroke_closed(self.feathering, &stroke.into(), out);
+            path.stroke_closed(self.feathering, &PathStroke::from(stroke).outside(), out);
         }
 
         self.feathering = old_feathering; // restore
@@ -1697,7 +1721,7 @@ impl Tessellator {
         out.vertices.reserve(galley.num_vertices);
         out.indices.reserve(galley.num_indices);
 
-        // The contents of the galley is already snapped to pixel coordinates,
+        // The contents of the galley are already snapped to pixel coordinates,
         // but we need to make sure the galley ends up on the start of a physical pixel:
         let galley_pos = pos2(
             self.round_to_pixel(galley_pos.x),

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -393,7 +393,7 @@ impl Fonts {
     ///
     /// This function will react to changes in `pixels_per_point` and `max_texture_side`,
     /// as well as notice when the font atlas is getting full, and handle that.
-    pub fn begin_frame(&self, pixels_per_point: f32, max_texture_side: usize) {
+    pub fn begin_frame(&self, pixels_per_point: f32, max_texture_side: usize) -> bool {
         let mut fonts_and_cache = self.0.lock();
 
         let pixels_per_point_changed = fonts_and_cache.fonts.pixels_per_point != pixels_per_point;
@@ -412,6 +412,7 @@ impl Fonts {
         }
 
         fonts_and_cache.galley_cache.flush_cache();
+        needs_recreate
     }
 
     /// Call at the end of each frame (before painting) to get the change to the font texture since last call.

--- a/crates/epaint/src/text/fonts.rs
+++ b/crates/epaint/src/text/fonts.rs
@@ -182,7 +182,8 @@ impl Default for FontTweak {
             scale: 1.0,
             y_offset_factor: 0.0,
             y_offset: 0.0,
-            baseline_offset_factor: -0.0333, // makes the default fonts look more centered in buttons and such
+            baseline_offset_factor: 0.0,
+            // baseline_offset_factor: -0.0333, // makes the default fonts look more centered in buttons and such
         }
     }
 }
@@ -292,7 +293,7 @@ impl Default for FontDefinitions {
 
                     // probably not correct, but this does make texts look better (#2724 for details)
                     y_offset_factor: 0.11, // move glyphs down to better align with common fonts
-                    baseline_offset_factor: -0.11, // ...now the entire row is a bit down so shift it back
+                    // baseline_offset_factor: -0.11, // ...now the entire row is a bit down so shift it back
                     ..Default::default()
                 },
             ),
@@ -778,6 +779,7 @@ impl FontImplCache {
                     font_name.to_owned(),
                     ab_glyph_font,
                     scale_in_pixels,
+                    scale_in_points,
                     tweak,
                 ))
             })

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -961,9 +961,10 @@ impl RowBreakCandidates {
             self.any
         } else {
             self.word_boundary()
+                // MEMBRANE: Prevent text from rendering vertically if there's not enough room for a single char.
                 .or(self.dash)
                 .or(self.punctuation)
-                .or(self.any)
+            // .or(self.any)
         }
     }
 


### PR DESCRIPTION
Uses an OffscreenCanvas to render glyphs instead of the `ab_glyph` rasterizer.

Benefits:

 - We can use OS native fonts that look nicer (i.e. `system-ui`, `SF Mono`). We can't embed these due to licensing issues.
 - Text shold look sharper since the OS rasterizer should use hints and/or better align outlines to the pixel grid
 - Smaller wasm files.

Future work:

  - Use `OffscreenCanvasRenderingContext2D.measureText` to measure text. Consider implementing the `ab_glyph::Font` trait in a struct that uses wasm_bindgen calls behind the scenes.
  - Test with system fonts

Limitations:

  - Generally speaking, the texture atlas approach of rendering text is limited by the fact that there's only one version of each glyph (one bitmap), but looking at how the browser renders text, each instance of e.g. the glyph "a", can rasterize to a slightly different bitmap, when they land on different non-integer coordinates. Egui does align each glyph to the pixel boundary in `text_layout.rs`
  
----

Status of this PR:

It works but glyphs look unaligned, I think it's because we don't use the canvas to _measure_ the glyphs and the metrics determined by `ab_glyph` don't match the metrics used by the canvas (canvas bounding boxes tend to be smaller, probably because grid alignment?)

