### PR TITLE
Hack: Sharper text by shifting/scaling the glyphs

### DIFF
--- a/crates/egui/src/widgets/checkbox.rs
+++ b/crates/egui/src/widgets/checkbox.rs
@@ -99,8 +99,6 @@ impl<'a> Widget for Checkbox<'a> {
             // let visuals = ui.style().interact_selectable(&response, *checked); // too colorful
             let visuals = ui.style().interact(&response);
             let (small_icon_rect, big_icon_rect) = ui.spacing().icon_rectangles(rect);
-            let small_icon_rect = ui.painter().round_rect_to_pixels(small_icon_rect);
-            let big_icon_rect = ui.painter().round_rect_to_pixels(big_icon_rect);
             ui.painter().add(epaint::RectShape::new(
                 big_icon_rect.expand(visuals.expansion),
                 visuals.rounding,

--- a/crates/egui/src/widgets/checkbox.rs
+++ b/crates/egui/src/widgets/checkbox.rs
@@ -99,6 +99,8 @@ impl<'a> Widget for Checkbox<'a> {
             // let visuals = ui.style().interact_selectable(&response, *checked); // too colorful
             let visuals = ui.style().interact(&response);
             let (small_icon_rect, big_icon_rect) = ui.spacing().icon_rectangles(rect);
+            let small_icon_rect = ui.painter().round_rect_to_pixels(small_icon_rect);
+            let big_icon_rect = ui.painter().round_rect_to_pixels(big_icon_rect);
             ui.painter().add(epaint::RectShape::new(
                 big_icon_rect.expand(visuals.expansion),
                 visuals.rounding,

--- a/crates/epaint/src/text/font.rs
+++ b/crates/epaint/src/text/font.rs
@@ -267,9 +267,16 @@ impl FontImpl {
         assert!(glyph_id.0 != 0);
         use ab_glyph::{Font as _, ScaleFont};
 
+        // MEMBRANE: HACK: Slightly shift and scale to improve grid alignment of JetBrainsMono
+        // TODO: This should be configurable via FontTweak
+        const MEMBRANE_FONT_SCALE: f32 = 1.04;
+        const MEMBRANE_FONT_SHIFT: f32 = 0.2;
         let glyph = glyph_id.with_scale_and_position(
-            self.scale_in_pixels as f32,
-            ab_glyph::Point { x: 0.0, y: 0.0 },
+            (self.scale_in_pixels as f32) * MEMBRANE_FONT_SCALE,
+            ab_glyph::Point {
+                x: 0.0,
+                y: -MEMBRANE_FONT_SHIFT,
+            },
         );
 
         let uv_rect = self.ab_glyph_font.outline_glyph(glyph).map(|glyph| {
@@ -312,7 +319,8 @@ impl FontImpl {
             .ab_glyph_font
             .as_scaled(self.scale_in_pixels as f32)
             .h_advance(glyph_id)
-            / self.pixels_per_point;
+            / self.pixels_per_point
+            * MEMBRANE_FONT_SCALE;
 
         GlyphInfo {
             id: glyph_id,


### PR DESCRIPTION
🚨 🚨 🚨 Even though this PR was merged. The merge commit was rebased and force-pushed later with a better implementation 🚨 🚨 🚨 

---- 
Slightly shifts and scales the glyph so that features better align with the pixel grid.

This Before/After video is compressed by github so it's harder to see the difference. Noticeable in the text that reads `Ready`.

https://github.com/user-attachments/assets/efe37f95-18bb-452b-b5a2-333037111336

