### PR TITLE
Comment out autofocusing input

### DIFF
--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -22,7 +22,8 @@ impl TextAgent {
             .create_element("input")?
             .dyn_into::<web_sys::HtmlInputElement>()?;
         input.set_type("text");
-        input.set_autofocus(true);
+        // MEMBRANE: browser blocks autofocus in a cross-origin iframe
+        // input.set_autofocus(true);
         input.set_attribute("autocapitalize", "off")?;
 
         // append it to `<body>` and hide it outside of the viewport


### PR DESCRIPTION
The browser blocks autofocusing from an iframe:

<img width="607" alt="Screenshot 2025-01-10 at 3 03 36 PM" src="https://github.com/user-attachments/assets/cf35abca-c181-4664-aaaf-c465c589d7c8" />
