### PR TITLE
make sure native drag starts get occluded

### DIFF
--- a/crates/egui/src/response.rs
+++ b/crates/egui/src/response.rs
@@ -363,7 +363,7 @@ impl Response {
     /// MEMBRANE: Is a native drag starting on this widget?
     #[inline]
     pub fn native_drag_started(&self) -> bool {
-        self.contains_pointer() && self.ctx.input(|i| i.raw.native_drag_starting)
+        self.hovered() && self.ctx.input(|i| i.raw.native_drag_starting)
     }
 
     /// The widget is being dragged.


### PR DESCRIPTION
makes sure dragging overlays such as the scrollbar won't unintentionally start a native drag