### PR TITLE
Promote f32 to Vec2

### DIFF
--- a/crates/emath/src/vec2.rs
+++ b/crates/emath/src/vec2.rs
@@ -89,6 +89,13 @@ impl From<&Vec2> for (f32, f32) {
     }
 }
 
+impl From<f32> for Vec2 {
+    #[inline(always)]
+    fn from(v: f32) -> Self {
+        Self { x: v, y: v }
+    }
+}
+
 impl From<Vec2b> for Vec2 {
     #[inline(always)]
     fn from(v: Vec2b) -> Self {


### PR DESCRIPTION
  Add `From<f32>` for `Vec2` (scalar-to-vector promotion)

  Implements `From<f32>` for `Vec2` via `Vec2::splat()`, matching the existing pattern of `From<Vec2b>` for
  `Vec2`. This enables `.into()` conversions from scalar to vector, which is useful when working with fields
  like `TextFormat::expand_bg` generically.
