### PR TITLE
Revert keeping section_index in Glyph

### DIFF
--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -1034,11 +1034,9 @@ fn galley_from_rows(
         num_indices += row.visuals.mesh.indices.len();
 
         row.section_index_at_start = u32::MAX; // No longer in use.
-
-        // MEMBRANE: Keep these values since we use them to render Markdown
-        // for glyph in &mut row.glyphs {
-        //     glyph.section_index = u32::MAX; // No longer in use.
-        // }
+        for glyph in &mut row.glyphs {
+            glyph.section_index = u32::MAX; // No longer in use.
+        }
     }
 
     let mut galley = Galley {

--- a/crates/epaint/src/text/text_layout_types.rs
+++ b/crates/epaint/src/text/text_layout_types.rs
@@ -885,8 +885,7 @@ pub struct Glyph {
     /// Only used during layout, then set to an invalid value in order to
     /// enable the paragraph-concat optimization path without having to
     /// adjust `section_index` when concatting.
-    /// MEMBRANE: Keep these values since we use them to render Markdown
-    pub section_index: u32,
+    pub(crate) section_index: u32,
 
     /// Which is our first vertex in [`RowVisuals::mesh`].
     pub first_vertex: u32,


### PR DESCRIPTION
Reverts e190b29f6 ("Keep section_index in Glyph to maintain support for MarkdownLabel").

### Why

Upstream blanks `Glyph::section_index` to `u32::MAX` in `galley_from_rows` precisely so that `Galley::concat` is valid — the field's own doc comment says so:

> Only used during layout, then set to an invalid value in order to enable the paragraph-concat optimization path without having to adjust `section_index` when concatting.

`GalleyCache::layout_each_paragraph_individually` lays out each paragraph as its own `LayoutJob` whose sections are re-indexed from zero, then `Galley::concat` splices the resulting `Arc<Row>`s in unchanged. So a glyph that is section 2 in the whole job is section 0 in its paragraph's sub-job.

Keeping the field therefore:

- broke `text::fonts::tests::test_split_paragraphs`, which asserts the split and whole layout paths produce identical galleys (fails on the 3-section job at `pixels_per_point: 1.00`, `section_index: 0` vs `2`);
- left wrong indices on any real multi-section galley that goes through the split path (multi-section, contains `\n`, `max_rows == usize::MAX`) — i.e. exactly the markdown case it was added for.

Making the indices correct on the split path isn't practical: `concat` shares each `Arc<Row>` straight out of the per-paragraph cache, so remapping after the fact means cloning every row and giving up the caching that path exists for.

### Nothing needs it

No code outside epaint reads `Glyph::section_index`. `egui_markdown` resolves sections via `section_for_char(&galley.job, char_index)`, which walks the job's byte ranges and never touches the glyph field. The in-crate readers (`add_row_backgrounds`, underline/strikethrough in `text_layout.rs`) all run before the reset.

### Testing

`cargo test -p epaint`: 43 passed, 1 failed. `test_split_paragraphs` now passes. The remaining failure, `text::text_layout::tests::test_truncate_with_pixels_per_point`, is pre-existing on `membrane` and unrelated — it is caused by 01cf491a0 commenting out the `.or(self.any)` fallback in `RowBreakCandidates::get`, so a run of identical characters with no space/dash/punctuation has no break candidate, overruns `wrap_width`, and never sets `elided`. Left alone here.

Also verified the gaze workspace and `egui_markdown` still compile against this.

https://claude.ai/code/session_01EXECzRjKJWJEvU2fMURDEr